### PR TITLE
Fix: Auto-close mobile navigation menu on item selection

### DIFF
--- a/MOBILE_MENU_FIX.md
+++ b/MOBILE_MENU_FIX.md
@@ -1,0 +1,130 @@
+# Mobile Navigation Menu Auto-Close Fix
+
+## Issue
+
+GitHub Issue #13: Mobile navigation menu (burger menu) doesn't automatically close after selecting a navigation item, requiring manual close which is poor UX.
+
+## Solution
+
+Implemented controlled state management for the mobile navigation menu to automatically close when a navigation item is clicked.
+
+## Changes Made
+
+### 1. Added Menu State Management
+
+Added `isMenuOpen` state to track and control the menu's open/closed status:
+
+```tsx
+const [isMenuOpen, setIsMenuOpen] = useState(false);
+```
+
+### 2. Connected State to Navbar Component
+
+Updated the `HeroUINavbar` component to use controlled state:
+
+```tsx
+<HeroUINavbar
+  isBordered
+  isMenuOpen={isMenuOpen}
+  maxWidth='xl'
+  position='sticky'
+  onMenuOpenChange={setIsMenuOpen}
+>
+```
+
+This allows the component to:
+
+- Track when the menu is opened/closed
+- Respond to toggle button clicks
+- Be controlled programmatically
+
+### 3. Added Click Handler to Navigation Items
+
+Added `onClick` handler to each navigation link in the mobile menu:
+
+```tsx
+<Link
+  as={NextLink}
+  color='foreground'
+  href={item.href}
+  size='lg'
+  className={clsx(
+    'transition-colors',
+    isActive(item.href)
+      ? 'text-green-600 font-semibold'
+      : 'hover:text-green-600'
+  )}
+  onClick={() => setIsMenuOpen(false)}
+>
+  {item.label}
+</Link>
+```
+
+**Note:** Props are ordered according to ESLint rules:
+
+1. Standard props (alphabetically)
+2. `className` (multiline)
+3. `onClick` (callback - must be last)
+
+## Behavior
+
+### Before
+
+- User clicks hamburger menu → menu opens
+- User clicks navigation item → navigates to page BUT menu stays open
+- User must manually click hamburger or outside to close menu
+
+### After
+
+- User clicks hamburger menu → menu opens
+- User clicks navigation item → navigates to page AND menu automatically closes
+- Provides smooth, expected mobile UX
+
+## Technical Details
+
+### Why Authentication Buttons Don't Close Menu
+
+The Sign In/Sign Up buttons in the mobile menu open modal dialogs (`mode='modal'`), so they intentionally don't close the menu. This allows users to:
+
+1. See the authentication modal overlay
+2. Cancel the modal if needed
+3. Still have the menu available
+
+### State Management Pattern
+
+Using controlled component pattern with HeroUI:
+
+- `isMenuOpen`: Controls the current state
+- `onMenuOpenChange`: Callback when state should change (toggle button clicks)
+- `onClick` on links: Programmatic state updates
+
+## Testing
+
+### Manual Testing Steps
+
+1. Open the application on a mobile viewport (< 640px width)
+2. Click the hamburger menu icon
+3. Verify menu opens
+4. Click any navigation item (Home, Cabins, About, etc.)
+5. Verify:
+   - Navigation occurs successfully
+   - Menu automatically closes
+   - No manual close action needed
+
+### Test on Multiple Screens
+
+- Mobile phone (320px - 375px width)
+- Tablet portrait (768px width)
+- Small desktop (< 640px width)
+
+## Files Modified
+
+- `/components/navbar.tsx`: Added state management and onClick handlers
+
+## Related Issues
+
+- Closes #13: Mobile navigation menu auto-close
+
+## Development Server
+
+The fix can be tested at: http://localhost:3001

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -32,6 +32,7 @@ export const Navbar = () => {
   const pathname = usePathname();
   const { theme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   // Only render logo after component has mounted to avoid hydration issues
   useEffect(() => {
@@ -46,7 +47,13 @@ export const Navbar = () => {
   };
 
   return (
-    <HeroUINavbar isBordered maxWidth='xl' position='sticky'>
+    <HeroUINavbar
+      isBordered
+      isMenuOpen={isMenuOpen}
+      maxWidth='xl'
+      position='sticky'
+      onMenuOpenChange={setIsMenuOpen}
+    >
       <NavbarContent className='basis-1/5 sm:basis-full' justify='start'>
         <NavbarBrand as='li' className='gap-3 max-w-fit'>
           <NextLink className='flex justify-start items-center gap-2' href='/'>
@@ -161,6 +168,7 @@ export const Navbar = () => {
                     ? 'text-green-600 font-semibold'
                     : 'hover:text-green-600'
                 )}
+                onClick={() => setIsMenuOpen(false)}
               >
                 {item.label}
               </Link>


### PR DESCRIPTION
## Description
This PR fixes issue #13 where the mobile navigation menu (hamburger menu) doesn't automatically close after selecting a navigation item.

## Changes
- Added controlled state management for mobile menu using `isMenuOpen` state
- Connected state to HeroUINavbar component with `isMenuOpen` and `onMenuOpenChange` props
- Added `onClick` handler to navigation links that closes the menu automatically
- Maintains expected mobile UX where menu closes after navigation
- Authentication buttons (Sign In/Sign Up) intentionally don't close the menu as they open modal dialogs

## Testing
The fix has been tested and:
- Menu opens when hamburger icon is clicked
- Menu automatically closes when navigation item is selected
- Navigation works correctly
- Authentication modals still work as expected

## Files Changed
- `components/navbar.tsx`: Added state management and onClick handlers
- `MOBILE_MENU_FIX.md`: Documentation of the fix

Closes #13