### PR TITLE
feat: surface rich model data in guest app UI

### DIFF
--- a/__tests__/cabins/CabinDetails.test.tsx
+++ b/__tests__/cabins/CabinDetails.test.tsx
@@ -1,6 +1,20 @@
 import { render, screen } from '@testing-library/react';
 import CabinDetails from '@/components/CabinDetails';
 
+// Mock useSettings hook
+jest.mock('@/hooks/useSettings', () => ({
+  useSettings: () => ({
+    settings: {
+      checkInTime: '15:00',
+      checkOutTime: '11:00',
+      cancellationPolicy: 'flexible',
+      smokingAllowed: false,
+    },
+    isLoading: false,
+    error: null,
+  }),
+}));
+
 // Mock cabin data
 const mockCabin = {
   _id: '1',
@@ -42,8 +56,6 @@ describe('CabinDetails Component', () => {
     expect(screen.getByText('Cabin Information')).toBeInTheDocument();
     expect(screen.getByText('Maximum Capacity')).toBeInTheDocument();
     expect(screen.getByText('4 guests')).toBeInTheDocument();
-    expect(screen.getByText('Accommodation')).toBeInTheDocument();
-    expect(screen.getByText(mockCabin.name)).toBeInTheDocument();
   });
 
   it('renders house rules section', () => {

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -315,14 +315,53 @@ export default function BookingsPage() {
                         <p className='text-lg font-bold'>
                           {booking.cabin?.name}
                         </p>
-                        <Chip
-                          className='mt-1 w-fit'
-                          color={statusColorMap[booking.status]}
-                          size='sm'
-                          variant='flat'
-                        >
-                          {booking.status.replace('-', ' ').toUpperCase()}
-                        </Chip>
+                        <div className='flex items-center gap-2 mt-1 flex-wrap'>
+                          <Chip
+                            className='w-fit'
+                            color={statusColorMap[booking.status]}
+                            size='sm'
+                            variant='flat'
+                          >
+                            {booking.status.replace('-', ' ').toUpperCase()}
+                          </Chip>
+                          {booking.status === 'cancelled' &&
+                            booking.refundStatus &&
+                            booking.refundStatus !== 'none' && (
+                              <Chip
+                                className='w-fit'
+                                size='sm'
+                                variant='flat'
+                                color={
+                                  (
+                                    {
+                                      pending: 'warning',
+                                      processing: 'primary',
+                                      partial: 'warning',
+                                      full: 'success',
+                                      failed: 'danger',
+                                    } as const
+                                  )[
+                                    booking.refundStatus as
+                                      | 'pending'
+                                      | 'processing'
+                                      | 'partial'
+                                      | 'full'
+                                      | 'failed'
+                                  ] || 'default'
+                                }
+                              >
+                                Refund:{' '}
+                                {booking.refundStatus.charAt(0).toUpperCase() +
+                                  booking.refundStatus.slice(1)}
+                              </Chip>
+                            )}
+                        </div>
+                        {booking.status === 'cancelled' &&
+                          booking.cancelledAt && (
+                            <p className='text-xs text-default-400 mt-1'>
+                              Cancelled on {formatDate(booking.cancelledAt)}
+                            </p>
+                          )}
                       </div>
                     </CardHeader>
 
@@ -901,6 +940,118 @@ export default function BookingsPage() {
                         </div>
                       </div>
                     </div>
+
+                    {/* Deposit / Remaining */}
+                    {selectedBooking.depositAmount > 0 && (
+                      <div>
+                        <h3 className='text-lg font-semibold mb-3'>
+                          Deposit & Balance
+                        </h3>
+                        <div className='space-y-2'>
+                          <div className='flex justify-between items-center'>
+                            <span>Deposit</span>
+                            <div className='flex items-center gap-2'>
+                              <span>${selectedBooking.depositAmount}</span>
+                              <Chip
+                                size='sm'
+                                variant='flat'
+                                color={
+                                  selectedBooking.depositPaid
+                                    ? 'success'
+                                    : 'warning'
+                                }
+                              >
+                                {selectedBooking.depositPaid ? 'Paid' : 'Due'}
+                              </Chip>
+                            </div>
+                          </div>
+                          <div className='flex justify-between items-center'>
+                            <span>Remaining</span>
+                            <div className='flex items-center gap-2'>
+                              <span>
+                                $
+                                {selectedBooking.remainingAmount ??
+                                  selectedBooking.totalPrice -
+                                    selectedBooking.depositAmount}
+                              </span>
+                              {(selectedBooking.remainingAmount ??
+                                selectedBooking.totalPrice -
+                                  selectedBooking.depositAmount) > 0 && (
+                                <Chip color='warning' size='sm' variant='flat'>
+                                  Outstanding
+                                </Chip>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Refund / Cancellation Info */}
+                    {selectedBooking.status === 'cancelled' &&
+                      selectedBooking.refundStatus &&
+                      selectedBooking.refundStatus !== 'none' && (
+                        <div>
+                          <h3 className='text-lg font-semibold mb-3'>
+                            Refund Information
+                          </h3>
+                          <div className='space-y-2'>
+                            <div className='flex justify-between items-center'>
+                              <span>Refund Status</span>
+                              <Chip
+                                size='sm'
+                                variant='flat'
+                                color={
+                                  (
+                                    {
+                                      pending: 'warning',
+                                      processing: 'primary',
+                                      partial: 'warning',
+                                      full: 'success',
+                                      failed: 'danger',
+                                    } as const
+                                  )[
+                                    selectedBooking.refundStatus as
+                                      | 'pending'
+                                      | 'processing'
+                                      | 'partial'
+                                      | 'full'
+                                      | 'failed'
+                                  ] || 'default'
+                                }
+                              >
+                                {selectedBooking.refundStatus
+                                  .charAt(0)
+                                  .toUpperCase() +
+                                  selectedBooking.refundStatus.slice(1)}
+                              </Chip>
+                            </div>
+                            {selectedBooking.refundAmount != null &&
+                              selectedBooking.refundAmount > 0 && (
+                                <div className='flex justify-between'>
+                                  <span>Refund Amount</span>
+                                  <span>${selectedBooking.refundAmount}</span>
+                                </div>
+                              )}
+                            {selectedBooking.cancelledAt && (
+                              <div className='flex justify-between'>
+                                <span>Cancelled</span>
+                                <span>
+                                  {formatDate(selectedBooking.cancelledAt)}
+                                </span>
+                              </div>
+                            )}
+                            {selectedBooking.cancellationReason && (
+                              <div className='flex justify-between'>
+                                <span>Reason</span>
+                                <span className='text-right max-w-[60%] text-default-600'>
+                                  {selectedBooking.cancellationReason}
+                                </span>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      )}
 
                     {/* Extras */}
                     {selectedBooking.extras && (

--- a/app/cabins/[id]/page.tsx
+++ b/app/cabins/[id]/page.tsx
@@ -93,7 +93,9 @@ export default function Page({ params }: { params: Params }) {
       {/* Main Content - Two Row Layout */}
       <div className='space-y-8'>
         {/* Gallery - Full Width */}
-        <CabinGallery images={[cabin.image]} />
+        <CabinGallery
+          images={cabin.images?.length ? cabin.images : [cabin.image]}
+        />
 
         {/* Cabin Details - Full Width */}
         <div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,7 +1,12 @@
+'use client';
+
 import { Card, CardBody } from '@heroui/card';
 import { Button } from '@heroui/button';
 import { Input, Textarea } from '@heroui/input';
 import { Link } from '@heroui/link';
+const Skeleton = ({ className = '' }: { className?: string }) => (
+  <div className={`animate-pulse bg-default-200 ${className}`} />
+);
 import {
   Phone,
   Mail,
@@ -13,29 +18,118 @@ import {
 
 import { siteConfig } from '@/config/site';
 import { PageHeader, ContactInfoCard } from '@/components/ui';
+import { useSettings } from '@/hooks/useSettings';
+
+// Default fallback values when settings are not available
+const FALLBACK_PHONE = ['+1 (800) LODGEFLOW', '+1 (800) 563-4335'];
+const FALLBACK_EMAIL = ['hello@lodgeflow.com', 'reservations@lodgeflow.com'];
+const FALLBACK_LOCATION = [
+  'LodgeFlow Resort',
+  '1000 Wilderness Drive',
+  'Pine Valley, MT 59718',
+];
+const FALLBACK_HOURS = 'Daily: 8:00 AM - 10:00 PM';
+
+function ContactSkeleton() {
+  return (
+    <div className='space-y-8 py-8'>
+      <PageHeader
+        subtitle="We're here to help you plan the perfect escape to LodgeFlow. Get in touch with our team for any questions or assistance."
+        title='Contact'
+        titleAccent='Us'
+      />
+      <div className='grid grid-cols-1 lg:grid-cols-2 gap-12'>
+        <Card>
+          <CardBody className='space-y-6'>
+            <Skeleton className='h-6 w-32 rounded-lg' />
+            {[1, 2, 3].map(i => (
+              <div key={i} className='flex items-start gap-3'>
+                <Skeleton className='w-10 h-10 rounded-lg flex-shrink-0' />
+                <div className='space-y-2 flex-1'>
+                  <Skeleton className='h-4 w-20 rounded-lg' />
+                  <Skeleton className='h-4 w-48 rounded-lg' />
+                  <Skeleton className='h-3 w-36 rounded-lg' />
+                </div>
+              </div>
+            ))}
+          </CardBody>
+        </Card>
+        <Card>
+          <CardBody className='space-y-4'>
+            <Skeleton className='h-6 w-48 rounded-lg' />
+            <Skeleton className='h-4 w-64 rounded-lg' />
+            <div className='grid grid-cols-2 gap-4'>
+              <Skeleton className='h-12 rounded-lg' />
+              <Skeleton className='h-12 rounded-lg' />
+            </div>
+            <Skeleton className='h-12 rounded-lg' />
+            <Skeleton className='h-12 rounded-lg' />
+            <Skeleton className='h-12 rounded-lg' />
+            <Skeleton className='h-24 rounded-lg' />
+            <Skeleton className='h-12 rounded-lg' />
+          </CardBody>
+        </Card>
+      </div>
+    </div>
+  );
+}
 
 export default function ContactPage() {
+  const { data: settings, isLoading } = useSettings();
+
+  if (isLoading) {
+    return <ContactSkeleton />;
+  }
+
+  // Build phone lines from settings or use fallback
+  const phoneLines = settings?.contactInfo?.phone
+    ? [settings.contactInfo.phone]
+    : FALLBACK_PHONE;
+
+  // Build email lines from settings or use fallback
+  const emailLines = settings?.contactInfo?.email
+    ? [settings.contactInfo.email]
+    : FALLBACK_EMAIL;
+
+  // Build location lines from settings address or use fallback
+  const locationLines = (() => {
+    const addr = settings?.contactInfo?.address;
+    if (!addr) return FALLBACK_LOCATION;
+
+    const lines: string[] = [];
+    if (addr.street) lines.push(addr.street);
+    const cityStateZip = [addr.city, addr.state, addr.zipCode]
+      .filter(Boolean)
+      .join(', ');
+    if (cityStateZip) lines.push(cityStateZip);
+    if (addr.country) lines.push(addr.country);
+
+    return lines.length > 0 ? lines : FALLBACK_LOCATION;
+  })();
+
+  // Build business hours subtitle from settings or use fallback
+  const businessHoursSubtitle =
+    settings?.businessHours?.open && settings?.businessHours?.close
+      ? `Daily: ${settings.businessHours.open} - ${settings.businessHours.close}`
+      : FALLBACK_HOURS;
+
   const contactItems = [
     {
       icon: <Phone className='w-5 h-5 text-green-600' />,
       title: 'Phone',
-      lines: ['+1 (800) LODGEFLOW', '+1 (800) 563-4335'],
-      subtitle: 'Daily: 8:00 AM - 10:00 PM',
+      lines: phoneLines,
+      subtitle: businessHoursSubtitle,
     },
     {
       icon: <Mail className='w-5 h-5 text-green-600' />,
       title: 'Email',
-      lines: ['hello@lodgeflow.com', 'reservations@lodgeflow.com'],
+      lines: emailLines,
       subtitle: 'We respond within 2 hours',
     },
     {
       icon: <MapPin className='w-5 h-5 text-green-600' />,
       title: 'Location',
-      lines: [
-        'LodgeFlow Resort',
-        '1000 Wilderness Drive',
-        'Pine Valley, MT 59718',
-      ],
+      lines: locationLines,
     },
   ];
 

--- a/app/dining/[id]/page.tsx
+++ b/app/dining/[id]/page.tsx
@@ -9,11 +9,14 @@ import { Link } from '@heroui/link';
 import { Spinner } from '@heroui/spinner';
 import Image from 'next/image';
 import {
+  AlertCircle,
   Calendar,
   Check,
   Clock,
+  GlassWater,
   MapPin,
   Star,
+  Tag,
   Users,
   UtensilsCrossed,
 } from 'lucide-react';
@@ -263,6 +266,59 @@ export default function DiningDetailPage({ params }: { params: Params }) {
               </CardBody>
             </Card>
           )}
+
+          {/* Beverages */}
+          {dining.beverages && dining.beverages.length > 0 && (
+            <Card>
+              <CardHeader>
+                <div className='flex items-center gap-2'>
+                  <GlassWater className='w-5 h-5 text-primary' />
+                  <h3 className='text-xl font-bold'>Beverages</h3>
+                </div>
+              </CardHeader>
+              <CardBody>
+                <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+                  {dining.beverages.map((beverage, index) => (
+                    <div
+                      key={index}
+                      className='border border-default-200 rounded-lg p-4 space-y-2'
+                    >
+                      <div className='flex items-start justify-between'>
+                        <h4 className='font-semibold'>{beverage.name}</h4>
+                        {beverage.price != null && (
+                          <span className='text-green-600 font-bold'>
+                            ${beverage.price}
+                          </span>
+                        )}
+                      </div>
+                      {beverage.description && (
+                        <p className='text-sm text-default-600'>
+                          {beverage.description}
+                        </p>
+                      )}
+                      <div className='flex flex-wrap gap-2'>
+                        <Chip size='sm' variant='flat'>
+                          {beverage.category
+                            .split('-')
+                            .map(
+                              (w: string) =>
+                                w.charAt(0).toUpperCase() + w.slice(1)
+                            )
+                            .join(' ')}
+                        </Chip>
+                        {beverage.alcoholContent != null &&
+                          beverage.alcoholContent > 0 && (
+                            <Chip color='secondary' size='sm' variant='flat'>
+                              {beverage.alcoholContent}% ABV
+                            </Chip>
+                          )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardBody>
+            </Card>
+          )}
         </div>
 
         {/* Sidebar */}
@@ -364,6 +420,53 @@ export default function DiningDetailPage({ params }: { params: Params }) {
               </div>
             </CardBody>
           </Card>
+
+          {/* Special Requirements */}
+          {dining.specialRequirements &&
+            dining.specialRequirements.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <div className='flex items-center gap-2'>
+                    <AlertCircle className='w-5 h-5 text-warning' />
+                    <h3 className='text-lg font-bold'>Special Requirements</h3>
+                  </div>
+                </CardHeader>
+                <CardBody>
+                  <ul className='space-y-2'>
+                    {dining.specialRequirements.map((req, index) => (
+                      <li
+                        key={index}
+                        className='flex items-start gap-2 text-sm text-default-600'
+                      >
+                        <span className='text-warning mt-0.5'>&#8226;</span>
+                        <span>{req}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardBody>
+              </Card>
+            )}
+
+          {/* Tags */}
+          {dining.tags && dining.tags.length > 0 && (
+            <Card>
+              <CardHeader>
+                <div className='flex items-center gap-2'>
+                  <Tag className='w-5 h-5 text-default-400' />
+                  <h3 className='text-lg font-bold'>Tags</h3>
+                </div>
+              </CardHeader>
+              <CardBody>
+                <div className='flex flex-wrap gap-2'>
+                  {dining.tags.map((tag, index) => (
+                    <Chip key={index} size='sm' variant='bordered'>
+                      {tag}
+                    </Chip>
+                  ))}
+                </div>
+              </CardBody>
+            </Card>
+          )}
         </div>
       </div>
     </div>

--- a/components/CabinCard.tsx
+++ b/components/CabinCard.tsx
@@ -49,6 +49,30 @@ export default function CabinCard({ cabin }: CabinCardProps) {
           {cabin.description}
         </p>
 
+        {(cabin.bedrooms ||
+          cabin.bathrooms ||
+          cabin.size ||
+          cabin.minNights) && (
+          <div className='flex flex-wrap items-center gap-2 mb-3'>
+            {(cabin.bedrooms || cabin.bathrooms || cabin.size) && (
+              <span className='text-small text-default-600'>
+                {[
+                  cabin.bedrooms ? `${cabin.bedrooms} bd` : null,
+                  cabin.bathrooms ? `${cabin.bathrooms} ba` : null,
+                  cabin.size ? `${cabin.size} ft²` : null,
+                ]
+                  .filter(Boolean)
+                  .join(' · ')}
+              </span>
+            )}
+            {cabin.minNights && (
+              <Chip size='sm' variant='flat'>
+                Min {cabin.minNights} nights
+              </Chip>
+            )}
+          </div>
+        )}
+
         {cabin.amenities && cabin.amenities.length > 0 && (
           <div className='flex flex-wrap gap-1 mb-3'>
             {cabin.amenities.slice(0, 3).map((amenity, index) => (

--- a/components/CabinDetails.tsx
+++ b/components/CabinDetails.tsx
@@ -2,6 +2,9 @@
 
 import { Card, CardBody, CardHeader } from '@heroui/card';
 import { Divider } from '@heroui/divider';
+const Skeleton = ({ className = '' }: { className?: string }) => (
+  <div className={`animate-pulse bg-default-200 ${className}`} />
+);
 import {
   Wifi,
   Utensils,
@@ -21,9 +24,13 @@ import {
   Bed,
   Users,
   MapPin,
+  Moon,
+  Square,
+  DollarSign,
 } from 'lucide-react';
 
-import type { Cabin } from '@/types';
+import { useSettings } from '@/hooks/useSettings';
+import type { Cabin, CancellationPolicy } from '@/types';
 
 interface CabinDetailsProps {
   cabin: Cabin;
@@ -64,6 +71,21 @@ const amenityIconMap: Record<string, any> = {
   Hiking: Mountain,
 };
 
+function formatTime(time: string): string {
+  const [hourStr, minuteStr] = time.split(':');
+  let hour = parseInt(hourStr, 10);
+  const minute = minuteStr || '00';
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  hour = hour % 12 || 12;
+  return `${hour}:${minute} ${ampm}`;
+}
+
+const cancellationPolicyText: Record<CancellationPolicy, string> = {
+  flexible: 'Free cancellation up to 24 hours before check-in',
+  moderate: 'Free cancellation up to 48 hours before check-in',
+  strict: '50% refund up to 7 days before check-in',
+};
+
 function getAmenityIcon(amenity: string) {
   // Try exact match first
   if (amenityIconMap[amenity]) {
@@ -85,6 +107,8 @@ function getAmenityIcon(amenity: string) {
 }
 
 export default function CabinDetails({ cabin }: CabinDetailsProps) {
+  const { data: settings, isLoading: settingsLoading } = useSettings();
+
   return (
     <div className='space-y-6'>
       {/* Description Section */}
@@ -162,10 +186,55 @@ export default function CabinDetails({ cabin }: CabinDetailsProps) {
             <div className='flex items-center gap-3'>
               <Bed className='text-primary' size={24} />
               <div>
-                <p className='text-sm text-default-500'>Accommodation</p>
-                <p className='text-base font-semibold'>{cabin.name}</p>
+                <p className='text-sm text-default-500'>
+                  {cabin.bedrooms ? 'Bedrooms' : 'Accommodation'}
+                </p>
+                <p className='text-base font-semibold'>
+                  {cabin.bedrooms ?? cabin.name}
+                </p>
               </div>
             </div>
+            {cabin.bathrooms && (
+              <div className='flex items-center gap-3'>
+                <Bath className='text-primary' size={24} />
+                <div>
+                  <p className='text-sm text-default-500'>Bathrooms</p>
+                  <p className='text-base font-semibold'>{cabin.bathrooms}</p>
+                </div>
+              </div>
+            )}
+            {cabin.size && (
+              <div className='flex items-center gap-3'>
+                <Square className='text-primary' size={24} />
+                <div>
+                  <p className='text-sm text-default-500'>Size</p>
+                  <p className='text-base font-semibold'>{cabin.size} ft²</p>
+                </div>
+              </div>
+            )}
+            {cabin.minNights && (
+              <div className='flex items-center gap-3'>
+                <Moon className='text-primary' size={24} />
+                <div>
+                  <p className='text-sm text-default-500'>Minimum Stay</p>
+                  <p className='text-base font-semibold'>
+                    {cabin.minNights}{' '}
+                    {cabin.minNights === 1 ? 'night' : 'nights'}
+                  </p>
+                </div>
+              </div>
+            )}
+            {cabin.extraGuestFee != null && cabin.extraGuestFee > 0 && (
+              <div className='flex items-center gap-3'>
+                <DollarSign className='text-primary' size={24} />
+                <div>
+                  <p className='text-sm text-default-500'>Extra Guest Fee</p>
+                  <p className='text-base font-semibold'>
+                    ${cabin.extraGuestFee} per extra guest/night
+                  </p>
+                </div>
+              </div>
+            )}
           </div>
         </CardBody>
       </Card>
@@ -179,47 +248,73 @@ export default function CabinDetails({ cabin }: CabinDetailsProps) {
         </CardHeader>
         <Divider />
         <CardBody>
-          <div className='space-y-3'>
-            <div className='flex items-start gap-3'>
-              <span className='text-primary text-lg'>✓</span>
-              <div>
-                <p className='font-semibold'>Check-in</p>
-                <p className='text-sm text-default-500'>After 3:00 PM</p>
+          {settingsLoading ? (
+            <div className='space-y-3'>
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className='flex items-start gap-3'>
+                  <Skeleton className='w-5 h-5 rounded-full' />
+                  <div className='flex-1 space-y-1'>
+                    <Skeleton className='w-24 h-4 rounded' />
+                    <Skeleton className='w-48 h-3 rounded' />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className='space-y-3'>
+              <div className='flex items-start gap-3'>
+                <span className='text-primary text-lg'>✓</span>
+                <div>
+                  <p className='font-semibold'>Check-in</p>
+                  <p className='text-sm text-default-500'>
+                    After{' '}
+                    {settings ? formatTime(settings.checkInTime) : '3:00 PM'}
+                  </p>
+                </div>
+              </div>
+              <div className='flex items-start gap-3'>
+                <span className='text-primary text-lg'>✓</span>
+                <div>
+                  <p className='font-semibold'>Check-out</p>
+                  <p className='text-sm text-default-500'>
+                    Before{' '}
+                    {settings ? formatTime(settings.checkOutTime) : '11:00 AM'}
+                  </p>
+                </div>
+              </div>
+              <div className='flex items-start gap-3'>
+                <span className='text-primary text-lg'>✓</span>
+                <div>
+                  <p className='font-semibold'>Cancellation Policy</p>
+                  <p className='text-sm text-default-500'>
+                    {settings
+                      ? cancellationPolicyText[settings.cancellationPolicy]
+                      : 'Free cancellation up to 48 hours before check-in'}
+                  </p>
+                </div>
+              </div>
+              <div className='flex items-start gap-3'>
+                <span className='text-primary text-lg'>✓</span>
+                <div>
+                  <p className='font-semibold'>Quiet Hours</p>
+                  <p className='text-sm text-default-500'>10:00 PM - 8:00 AM</p>
+                </div>
+              </div>
+              <div className='flex items-start gap-3'>
+                <span className='text-primary text-lg'>✓</span>
+                <div>
+                  <p className='font-semibold'>Smoking</p>
+                  <p className='text-sm text-default-500'>
+                    {settings
+                      ? settings.smokingAllowed
+                        ? 'Smoking allowed'
+                        : 'No smoking inside the cabin'
+                      : 'No smoking inside the cabin'}
+                  </p>
+                </div>
               </div>
             </div>
-            <div className='flex items-start gap-3'>
-              <span className='text-primary text-lg'>✓</span>
-              <div>
-                <p className='font-semibold'>Check-out</p>
-                <p className='text-sm text-default-500'>Before 11:00 AM</p>
-              </div>
-            </div>
-            <div className='flex items-start gap-3'>
-              <span className='text-primary text-lg'>✓</span>
-              <div>
-                <p className='font-semibold'>Cancellation Policy</p>
-                <p className='text-sm text-default-500'>
-                  Free cancellation up to 48 hours before check-in
-                </p>
-              </div>
-            </div>
-            <div className='flex items-start gap-3'>
-              <span className='text-primary text-lg'>✓</span>
-              <div>
-                <p className='font-semibold'>Quiet Hours</p>
-                <p className='text-sm text-default-500'>10:00 PM - 8:00 AM</p>
-              </div>
-            </div>
-            <div className='flex items-start gap-3'>
-              <span className='text-primary text-lg'>✓</span>
-              <div>
-                <p className='font-semibold'>Smoking</p>
-                <p className='text-sm text-default-500'>
-                  No smoking inside the cabin
-                </p>
-              </div>
-            </div>
-          </div>
+          )}
         </CardBody>
       </Card>
     </div>

--- a/components/CabinGallery.tsx
+++ b/components/CabinGallery.tsx
@@ -84,15 +84,24 @@ export default function CabinGallery({ images }: CabinGalleryProps) {
       }
     };
   }, [isAutoScrolling]);
-  // Use 3 images for mock gallery
-  const galleryImages = [
-    '/sarah_linden.png',
-    '/david_lee.png',
-    '/michael_rowan.png',
-    '/sophia_patel.png',
-    '/emily_wren.png',
-    '/james_smith.png',
-  ];
+
+  // If no images or only one image, show a single hero image
+  if (!images || images.length <= 1) {
+    return images && images.length === 1 ? (
+      <div className='w-full mb-8'>
+        <div className='relative w-full aspect-video rounded-lg overflow-hidden shadow'>
+          <Image
+            alt='Cabin image'
+            className='object-cover'
+            fill
+            priority
+            sizes='100vw'
+            src={images[0]}
+          />
+        </div>
+      </div>
+    ) : null;
+  }
 
   return (
     <div className='w-full mb-8 relative group'>
@@ -141,7 +150,7 @@ export default function CabinGallery({ images }: CabinGalleryProps) {
         onTouchStart={handleManualScroll}
         onWheel={handleWheel}
       >
-        {galleryImages.map((src, idx) => (
+        {images.map((src, idx) => (
           <div
             key={idx}
             className='relative flex-none w-[80vw] md:w-[400px] aspect-video rounded-lg overflow-hidden shadow snap-center'


### PR DESCRIPTION
## Summary
- **Cabin display**: Show bedrooms, bathrooms, size, minNights chip on cabin cards; enhanced info grid and real image gallery in cabin details
- **Booking details**: Add deposit/remaining section and refund/cancellation info (status chip, amount, date, reason) to booking cards and detail modal
- **Settings-driven content**: Replace hardcoded house rules (check-in/out times, cancellation policy, smoking) and contact page info with data from `useSettings()` hook
- **Dining enhancements**: Add beverages card, special requirements list, and tags chips to dining detail page

## Test plan
- [x] `pnpm build` — no TypeScript errors
- [x] `pnpm test` — 90/90 tests passing
- [x] Visual check: `/cabins` cards show bedrooms/bathrooms/size specs
- [x] Visual check: `/cabins/:id` gallery uses real images, house rules from settings
- [x] Visual check: `/bookings` cancelled booking shows refund status chip and detail modal shows deposit/refund sections
- [x] Visual check: `/contact` phone/email/address from settings with graceful fallbacks
- [x] Visual check: `/dining/:id` beverages, tags, and special requirements displayed