### PR TITLE
fix(security): close booking IDORs and broaden proxy auth gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ pnpm build            # Production build
 pnpm lint             # ESLint with auto-fix
 pnpm test             # Run all tests
 pnpm test:watch       # Run tests in watch mode
-pnpm test -- --testPathPattern="cabins"  # Run specific test file/folder
+pnpm exec jest --testPathPatterns=cabins # Run a subset (jest 30 renamed the flag — plural, and `pnpm test --` forwards arguments unreliably)
 pnpm format           # Format with Prettier
 pnpm ci:check         # Full CI check (format + lint + test)
 ```
@@ -46,13 +46,24 @@ Custom hooks in `hooks/` use React Query to fetch from internal API routes. API 
 
 ### Auth Routing (`proxy.ts`)
 
-Next.js 16 replaces `middleware.ts` with `proxy.ts`. Clerk middleware lives there and gates:
+Next.js 16 replaces `middleware.ts` with `proxy.ts`. Clerk middleware uses `createRouteMatcher` to gate these API surfaces:
 
-- Dynamic cabin detail pages (`/cabins/[id]`) require login
-- All `/api/bookings` routes require auth
-- Public API routes (`/api/cabins`, `/api/experiences`, `/api/dining`, `/api/settings`) are explicitly allowed
+- `/api/bookings(.*)`
+- `/api/dining-reservations(.*)`
+- `/api/experience-bookings(.*)`
+- `/api/payments(.*)` — **except** `/api/payments/webhook`, which is verified by Stripe signature. The handler short-circuits with an explicit early return for that path.
+- `/api/send(.*)`
 
-When adding new protected routes, update `proxy.ts` — not a file named `middleware.ts`.
+Public API routes (no auth): `/api/cabins`, `/api/experiences`, `/api/dining`, `/api/settings`. Pages are not gated — users can browse cabins anonymously and only need to sign in to book.
+
+When adding a new mutating API route, extend the `createRouteMatcher` list in `proxy.ts` — not a file named `middleware.ts`.
+
+### Auth conventions inside route handlers
+
+- **Derive `customer` from `await auth().userId` server-side.** Never accept a customer / user id from the request body — bodies are attacker-controlled. Booking/reservation create endpoints all follow this.
+- **Mutations and reads scoped to a specific resource** (e.g. `GET|PATCH|DELETE /api/bookings/[id]`) must verify `resource.customer.toString() === userId` after `findById`. On mismatch, return **404 with a "not found" body** — 403 leaks the existence of the resource.
+- The proxy is the primary gate; in-handler `await auth()` checks remain as defense in depth for any route that could be hit if the matcher list ever drifts.
+- Stripe webhook handler must use `stripe.webhooks.constructEvent` and check `ProcessedStripeEvent` for idempotency _before_ mutating booking state.
 
 ### Model Relationships
 
@@ -73,10 +84,13 @@ All API routes return `ApiResponse<T>`:
 
 ### Testing
 
-Tests live in `__tests__/` organized by feature (bookings, cabins, lib, shared). Jest with React Testing Library. Framer-motion is mocked in `__tests__/__mocks__/`.
+Tests live in `__tests__/` organized by feature (bookings, cabins, lib, shared). Jest 30 with React Testing Library. Framer-motion is mocked in `__tests__/__mocks__/`.
 
-- HeroUI components also need manual mocks in `__tests__/__mocks__/@heroui/` — add one per package (e.g. `skeleton.js`, `tooltip.js`)
-- Components that use React Query (`useX` hooks) must be mocked in page-level tests to avoid needing `QueryClientProvider`
+- HeroUI components need manual mocks in `__tests__/__mocks__/@heroui/` — add one per package (e.g. `skeleton.js`, `tooltip.js`).
+- Components that use React Query hooks (`useX`) must mock those hooks in page-level tests to avoid needing `QueryClientProvider`. `BookingForm` in particular pulls in `useSettings` — any test that renders it must `jest.mock('@/hooks/useSettings', …)` even if it doesn't assert on settings.
+- Hook-level tests use `customRender` from `__tests__/shared/test-utils.tsx`, which wraps with a real `QueryClient` configured for tests (no retries, no caching).
+- Mongoose document types (`Cabin`, `Booking`, etc. re-exported from `types/index.ts`) extend `mongoose.Document` and **cannot be satisfied by plain mock objects** (53+ required fields, including `$assertPopulated` etc.). Cast at the fixture boundary: `const mockCabin = { … } as unknown as Cabin`. Spread variants like `{ ...mockCabin, capacity: 1 }` need their own cast — TS does not propagate the cast through spreads.
+- A `.worktrees/` directory is in `testPathIgnorePatterns`; jest still warns about haste-map collisions if a worktree is left behind. The warnings are noise.
 
 ### ESLint Rules
 

--- a/__tests__/bookings/BookingFormDiscount.test.tsx
+++ b/__tests__/bookings/BookingFormDiscount.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import BookingForm from '@/components/BookingForm';
 import { useCreateBooking } from '@/hooks/useBooking';
 import { useUser } from '@clerk/nextjs';
@@ -6,6 +6,13 @@ import { useRouter } from 'next/navigation';
 
 // Mock dependencies
 jest.mock('@/hooks/useBooking');
+jest.mock('@/hooks/useSettings', () => ({
+  useSettings: jest.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  })),
+}));
 jest.mock('@clerk/nextjs');
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),

--- a/__tests__/cabins/BookingFormMobile.test.tsx
+++ b/__tests__/cabins/BookingFormMobile.test.tsx
@@ -7,6 +7,13 @@ import { useRouter } from 'next/navigation';
 
 jest.mock('@/hooks/useBooking');
 jest.mock('@/hooks/useIsMobile');
+jest.mock('@/hooks/useSettings', () => ({
+  useSettings: jest.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    error: null,
+  })),
+}));
 jest.mock('@clerk/nextjs');
 jest.mock('next/navigation', () => ({ useRouter: jest.fn() }));
 jest.mock('swr', () => ({

--- a/__tests__/cabins/CabinAvailabilityPreview.test.tsx
+++ b/__tests__/cabins/CabinAvailabilityPreview.test.tsx
@@ -58,13 +58,14 @@ describe('CabinAvailabilityPreview', () => {
   });
 
   it('marks unavailable dates with danger styling', () => {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = now.getMonth();
-    // Pick a future date in the current month (day 20)
-    const futureDay = 20;
-    const startDate = `${year}-${String(month + 1).padStart(2, '0')}-${futureDay}`;
-    const endDate = `${year}-${String(month + 1).padStart(2, '0')}-${futureDay + 2}`;
+    // Pick dates a few days into the future to avoid the component skipping past days.
+    const toIso = (d: Date) => d.toISOString().slice(0, 10);
+    const startDateObj = new Date();
+    startDateObj.setDate(startDateObj.getDate() + 3);
+    const endDateObj = new Date();
+    endDateObj.setDate(endDateObj.getDate() + 5);
+    const startDate = toIso(startDateObj);
+    const endDate = toIso(endDateObj);
 
     (useCabinAvailability as jest.Mock).mockReturnValue({
       isLoading: false,

--- a/__tests__/cabins/CabinDetails.test.tsx
+++ b/__tests__/cabins/CabinDetails.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import CabinDetails from '@/components/CabinDetails';
+import type { Cabin } from '@/types';
 
 // Mock useSettings hook
 jest.mock('@/hooks/useSettings', () => ({
@@ -15,7 +16,7 @@ jest.mock('@/hooks/useSettings', () => ({
   }),
 }));
 
-// Mock cabin data
+// Mock cabin data — cast since UI components only consume a subset of ICabin
 const mockCabin = {
   _id: '1',
   name: 'Luxury Mountain Cabin',
@@ -26,7 +27,7 @@ const mockCabin = {
   description:
     'A beautiful mountain cabin with stunning views and modern amenities.',
   amenities: ['WiFi', 'Kitchen', 'Parking', 'Hot Tub', 'Mountain View'],
-};
+} as unknown as Cabin;
 
 describe('CabinDetails Component', () => {
   it('renders cabin description', () => {
@@ -72,7 +73,7 @@ describe('CabinDetails Component', () => {
     const cabinNoAmenities = {
       ...mockCabin,
       amenities: [],
-    };
+    } as unknown as Cabin;
 
     render(<CabinDetails cabin={cabinNoAmenities} />);
 
@@ -90,7 +91,7 @@ describe('CabinDetails Component', () => {
     const singleGuestCabin = {
       ...mockCabin,
       capacity: 1,
-    };
+    } as unknown as Cabin;
 
     render(<CabinDetails cabin={singleGuestCabin} />);
 

--- a/__tests__/cabins/CabinDetailsSections.test.tsx
+++ b/__tests__/cabins/CabinDetailsSections.test.tsx
@@ -5,6 +5,7 @@ import {
   CabinInfoSection,
   CabinHouseRulesSection,
 } from '@/components/CabinDetails';
+import type { Cabin } from '@/types';
 
 jest.mock('@/hooks/useSettings', () => ({
   useSettings: () => ({ data: null, isLoading: false }),
@@ -19,7 +20,7 @@ const mockCabin = {
   discount: 0,
   description: 'A beautiful mountain cabin.',
   amenities: ['WiFi', 'Kitchen'],
-};
+} as unknown as Cabin;
 
 describe('CabinDescriptionSection', () => {
   it('renders description heading and text', () => {
@@ -38,7 +39,9 @@ describe('CabinAmenitiesSection', () => {
 
   it('renders nothing when amenities array is empty', () => {
     const { container } = render(
-      <CabinAmenitiesSection cabin={{ ...mockCabin, amenities: [] }} />
+      <CabinAmenitiesSection
+        cabin={{ ...mockCabin, amenities: [] } as unknown as Cabin}
+      />
     );
     expect(container.firstChild).toBeNull();
   });

--- a/__tests__/cabins/CabinMobileTabs.test.tsx
+++ b/__tests__/cabins/CabinMobileTabs.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import CabinMobileTabs from '@/components/CabinMobileTabs';
+import type { Cabin } from '@/types';
 
 jest.mock('@/components/CabinDetails', () => ({
   CabinDescriptionSection: () => (
@@ -30,7 +31,7 @@ const mockCabin = {
   discount: 0,
   description: 'A test cabin.',
   amenities: ['WiFi'],
-};
+} as unknown as Cabin;
 
 const mockBookingCabin = {
   _id: 'cabin-123',

--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -13,16 +13,34 @@ import {
 } from '@/lib/validations/utils';
 
 export async function GET(
-  request: NextRequest,
+  _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Unauthorized',
+      };
+      return NextResponse.json(response, { status: 401 });
+    }
+
     await connectDB();
     const { id } = await params;
 
     const booking = await Booking.findById(id).populate('cabin');
 
     if (!booking) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Booking not found',
+      };
+      return NextResponse.json(response, { status: 404 });
+    }
+
+    if (booking.customer.toString() !== userId) {
       const response: ApiResponse<never> = {
         success: false,
         error: 'Booking not found',

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,6 +1,6 @@
 import { Booking, Cabin, connectDB, Settings } from '@/models';
 import type { ApiResponse, PopulatedBooking } from '@/types';
-import { clerkClient } from '@clerk/nextjs/server';
+import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 import { createBookingSchema } from '@/lib/validations';
 import {
@@ -9,6 +9,15 @@ import {
 } from '@/lib/validations/utils';
 export async function POST(request: NextRequest) {
   try {
+    const { userId } = await auth();
+    if (!userId) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Unauthorized',
+      };
+      return NextResponse.json(response, { status: 401 });
+    }
+
     await connectDB();
 
     const body = await request.json();
@@ -21,7 +30,6 @@ export async function POST(request: NextRequest) {
 
     const {
       cabinId,
-      customerId,
       checkInDate,
       checkOutDate,
       numGuests,
@@ -29,17 +37,6 @@ export async function POST(request: NextRequest) {
       specialRequests,
       observations,
     } = validation.data;
-
-    const client = await clerkClient();
-    const user = await client.users.getUser(customerId);
-
-    if (!user) {
-      const response: ApiResponse<never> = {
-        success: false,
-        error: 'Customer not found',
-      };
-      return NextResponse.json(response, { status: 404 });
-    }
 
     const checkIn = new Date(checkInDate);
     const checkOut = new Date(checkOutDate);
@@ -156,12 +153,10 @@ export async function POST(request: NextRequest) {
       ? Math.round(totalPrice * (settings.depositPercentage / 100))
       : 0;
 
-    // Ensure customer exists
-
     // Create booking
     const booking = await Booking.create({
       cabin: cabinId,
-      customer: customerId,
+      customer: userId,
       checkInDate: checkIn,
       checkOutDate: checkOut,
       numNights,

--- a/app/api/payments/[bookingId]/route.ts
+++ b/app/api/payments/[bookingId]/route.ts
@@ -43,12 +43,12 @@ export async function GET(
       return NextResponse.json(response, { status: 404 });
     }
 
-    if (booking.customer !== userId) {
+    if (booking.customer.toString() !== userId) {
       const response: ApiResponse<never> = {
         success: false,
-        error: 'Not authorized to view this payment status',
+        error: 'Booking not found',
       };
-      return NextResponse.json(response, { status: 403 });
+      return NextResponse.json(response, { status: 404 });
     }
 
     const paymentStatus: PaymentStatusData = {

--- a/components/BookingForm.tsx
+++ b/components/BookingForm.tsx
@@ -144,7 +144,6 @@ export default function BookingForm({ cabin, userData }: BookingFormProps) {
 
     const bookingData: CreateBookingData = {
       cabinId: cabin._id,
-      customerId: user.id,
       checkInDate: new Date(dateRange.start.toString()),
       checkOutDate: new Date(dateRange.end.toString()),
       numGuests: parseInt(numberOfGuests, 10),

--- a/lib/validations/booking.ts
+++ b/lib/validations/booking.ts
@@ -46,7 +46,6 @@ export const refundStatusSchema = z.enum(REFUND_STATUSES);
 export const createBookingSchema = z
   .object({
     cabinId: z.string().min(1, 'Cabin ID is required'),
-    customerId: z.string().min(1, 'Customer ID is required'),
     checkInDate: z.coerce.date(),
     checkOutDate: z.coerce.date(),
     numGuests: z.number().int().min(1, 'At least 1 guest required').max(50),

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,8 +1,19 @@
-import { clerkMiddleware } from '@clerk/nextjs/server';
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+
+const isProtectedApiRoute = createRouteMatcher([
+  '/api/bookings(.*)',
+  '/api/dining-reservations(.*)',
+  '/api/experience-bookings(.*)',
+  '/api/payments(.*)',
+  '/api/send(.*)',
+]);
 
 export default clerkMiddleware(async (auth, req) => {
-  // Protect API routes that create bookings or user-specific data
-  if (req.nextUrl.pathname.startsWith('/api/bookings')) {
+  // Stripe webhook is verified by signature, not Clerk session.
+  if (req.nextUrl.pathname === '/api/payments/webhook') {
+    return;
+  }
+  if (isProtectedApiRoute(req)) {
     await auth.protect();
   }
 });

--- a/types/index.ts
+++ b/types/index.ts
@@ -57,7 +57,6 @@ export interface UpdateCabinData extends Partial<CreateCabinData> {
 
 export interface CreateBookingData {
   cabinId: string;
-  customerId: string;
   checkInDate: Date;
   checkOutDate: Date;
   numGuests: number;


### PR DESCRIPTION
## Summary

- **Close two IDORs on `/api/bookings`.** Derive `customer` from `auth().userId` on `POST` (drop `customerId` from schema, type, and form payload). Add auth + ownership check to `GET /api/bookings/[id]`, returning 404 on mismatch so the endpoint doesn't leak existence.
- **Broaden `proxy.ts` gates.** Switch to `createRouteMatcher` covering bookings, dining-reservations, experience-bookings, payments, and send routes. The Stripe webhook short-circuits with an explicit early return so signature verification remains its sole gate.
- **Align `/api/payments/[bookingId]`** with the new pattern: `.toString()` compare and 404-on-mismatch.
- **Repair pre-existing test failures** uncovered while verifying: mock `useSettings` in `BookingForm` tests, cast cabin fixtures with `as unknown as Cabin`, and make `CabinAvailabilityPreview`'s "future date" relative to now instead of hard-coded.
- **Update `CLAUDE.md`** with the actual proxy gate list, auth conventions (customer from auth, 404 on IDOR, webhook idempotency), and test fixture notes.

## Test plan

- [ ] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec jest` — all 121 tests pass
- [x] `pnpm exec eslint` on touched files — clean
- [ ] Manual: signed-out user hitting `GET /api/bookings/<any-id>` → 401
- [ ] Manual: signed-in user hitting `GET /api/bookings/<other-user-booking>` → 404 (not 403)
- [ ] Manual: signed-in user creating a booking — `customer` field matches their Clerk userId regardless of any `customerId` value sent in the body
- [ ] Manual: Stripe webhook still receives events (signature-verified, not Clerk-gated)
- [ ] Manual: cabin browsing remains anonymous; sign-in is only required at booking submission
- [x] Vercel preview deploy succeeds (required by branch protection)