### PR TITLE
fix(security): close residual IDOR leaks in booking PATCH and DELETE

### DIFF
--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -111,9 +111,9 @@ export async function PATCH(
     if (booking.customer.toString() !== userId) {
       const response: ApiResponse<never> = {
         success: false,
-        error: 'Unauthorized to modify this booking',
+        error: 'Booking not found',
       };
-      return NextResponse.json(response, { status: 403 });
+      return NextResponse.json(response, { status: 404 });
     }
 
     // Prevent modifications to checked-in/checked-out bookings
@@ -208,9 +208,9 @@ export async function DELETE(
     if (booking.customer.toString() !== userId) {
       const response: ApiResponse<never> = {
         success: false,
-        error: 'Unauthorized to cancel this booking',
+        error: 'Booking not found',
       };
-      return NextResponse.json(response, { status: 403 });
+      return NextResponse.json(response, { status: 404 });
     }
 
     // Check if booking can be cancelled


### PR DESCRIPTION
Closes #70.

## Summary

Mirrors the GET-handler IDOR fix from PR #63 across the PATCH and DELETE handlers in the same file. Both branches now return **404** with body `'Booking not found'` on ownership mismatch — exact-match to the not-found branch a few lines above each — instead of the previous 403 which leaked the existence of foreign bookings.

## Files

- `app/api/bookings/[id]/route.ts:116` (PATCH ownership mismatch)
- `app/api/bookings/[id]/route.ts:213` (DELETE ownership mismatch)

4 lines changed total (status code + error string per branch).

## Why this needed a separate PR from #71

- #71 (closes #66) targets dining + experience-bookings handlers; this targets bookings — different files, no overlap
- Splitting keeps each PR's blast radius and review context tight
- These can land in either order; no merge conflicts between them

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec jest` — 121/121 passing, no regressions
- [x] Manual diff review: exactly the 2 mechanical edits described above
- [ ] Reviewer manually verifies a foreign-ID PATCH/DELETE returns 404 + `'Booking not found'` body (regression coverage will land with broader test coverage; not setting up handler-test infra in a 4-line PR)