### PR TITLE
feat(payments): wire Stripe checkout for dining and experiences

### DIFF
--- a/__tests__/bookings/usePaymentDiningExperience.test.tsx
+++ b/__tests__/bookings/usePaymentDiningExperience.test.tsx
@@ -1,0 +1,118 @@
+import { renderHook } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+
+import {
+  useCreateDiningCheckoutSession,
+  useCreateExperienceCheckoutSession,
+} from '@/hooks/usePayment';
+import { createTestQueryClient } from '@/__tests__/shared/test-utils';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={createTestQueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+describe('useCreateDiningCheckoutSession', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('posts to the dining checkout endpoint and returns the session url', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { url: 'https://checkout.stripe.com/dining-session' },
+        success: true,
+      }),
+    });
+
+    const { result } = renderHook(() => useCreateDiningCheckoutSession(), {
+      wrapper,
+    });
+
+    const data = await result.current.mutateAsync('reservation-1');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/payments/create-dining-checkout',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reservationId: 'reservation-1' }),
+      }
+    );
+    expect(data).toEqual({ url: 'https://checkout.stripe.com/dining-session' });
+  });
+
+  it('throws the server-provided error message on failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Reservation is already paid' }),
+    });
+
+    const { result } = renderHook(() => useCreateDiningCheckoutSession(), {
+      wrapper,
+    });
+
+    await expect(result.current.mutateAsync('reservation-1')).rejects.toThrow(
+      'Reservation is already paid'
+    );
+  });
+});
+
+describe('useCreateExperienceCheckoutSession', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('posts to the experience checkout endpoint and returns the session url', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: { url: 'https://checkout.stripe.com/experience-session' },
+        success: true,
+      }),
+    });
+
+    const { result } = renderHook(() => useCreateExperienceCheckoutSession(), {
+      wrapper,
+    });
+
+    const data = await result.current.mutateAsync('booking-1');
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/payments/create-experience-checkout',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bookingId: 'booking-1' }),
+      }
+    );
+    expect(data).toEqual({
+      url: 'https://checkout.stripe.com/experience-session',
+    });
+  });
+
+  it('throws the server-provided error message on failure', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Booking is already paid' }),
+    });
+
+    const { result } = renderHook(() => useCreateExperienceCheckoutSession(), {
+      wrapper,
+    });
+
+    await expect(result.current.mutateAsync('booking-1')).rejects.toThrow(
+      'Booking is already paid'
+    );
+  });
+});

--- a/app/api/payments/create-dining-checkout/route.ts
+++ b/app/api/payments/create-dining-checkout/route.ts
@@ -1,0 +1,128 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { connectDB, DiningReservation } from '@/models';
+import { getStripe } from '@/lib/stripe';
+import type { ApiResponse } from '@/types';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Authentication required',
+      };
+      return NextResponse.json(response, { status: 401 });
+    }
+
+    await connectDB();
+
+    const { reservationId } = await request.json();
+
+    if (!reservationId) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Reservation ID is required',
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    const reservation =
+      await DiningReservation.findById(reservationId).populate('dining');
+
+    if (!reservation) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Dining reservation not found',
+      };
+      return NextResponse.json(response, { status: 404 });
+    }
+
+    if (reservation.customer !== userId) {
+      // 404 not 403 — see CLAUDE.md auth conventions
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Dining reservation not found',
+      };
+      return NextResponse.json(response, { status: 404 });
+    }
+
+    if (reservation.isPaid) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Reservation is already paid',
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    if (
+      reservation.status === 'cancelled' ||
+      reservation.status === 'no-show'
+    ) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: `Cannot pay for a ${reservation.status} reservation`,
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    if (reservation.totalPrice <= 0) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Payment amount must be greater than zero',
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+    const stripe = getStripe();
+
+    const session = await stripe.checkout.sessions.create({
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: reservation.dining.name,
+              description: `Dining reservation for ${reservation.numGuests} guest${reservation.numGuests === 1 ? '' : 's'}`,
+            },
+            unit_amount: Math.round(reservation.totalPrice * 100),
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: {
+        diningReservationId: reservation._id.toString(),
+        userId,
+      },
+      payment_intent_data: {
+        metadata: {
+          diningReservationId: reservation._id.toString(),
+          userId,
+        },
+      },
+      mode: 'payment',
+      success_url: `${baseUrl}/dining/confirmation/${reservation._id}?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${baseUrl}/dining/confirmation/${reservation._id}`,
+    });
+
+    await DiningReservation.findByIdAndUpdate(reservationId, {
+      stripeSessionId: session.id,
+    });
+
+    const response: ApiResponse<{ url: string }> = {
+      success: true,
+      data: { url: session.url! },
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error('Error creating dining checkout session:', error);
+    const response: ApiResponse<never> = {
+      success: false,
+      error: 'Failed to create checkout session',
+    };
+    return NextResponse.json(response, { status: 500 });
+  }
+}

--- a/app/api/payments/create-experience-checkout/route.ts
+++ b/app/api/payments/create-experience-checkout/route.ts
@@ -1,0 +1,125 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { connectDB, ExperienceBooking } from '@/models';
+import { getStripe } from '@/lib/stripe';
+import type { ApiResponse } from '@/types';
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Authentication required',
+      };
+      return NextResponse.json(response, { status: 401 });
+    }
+
+    await connectDB();
+
+    const { bookingId } = await request.json();
+
+    if (!bookingId) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Booking ID is required',
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    const booking =
+      await ExperienceBooking.findById(bookingId).populate('experience');
+
+    if (!booking) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Experience booking not found',
+      };
+      return NextResponse.json(response, { status: 404 });
+    }
+
+    if (booking.customer !== userId) {
+      // 404 not 403 — see CLAUDE.md auth conventions
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Experience booking not found',
+      };
+      return NextResponse.json(response, { status: 404 });
+    }
+
+    if (booking.isPaid) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Booking is already paid',
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    if (booking.status === 'cancelled') {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Cannot pay for a cancelled booking',
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    if (booking.totalPrice <= 0) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Payment amount must be greater than zero',
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+    const stripe = getStripe();
+
+    const session = await stripe.checkout.sessions.create({
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: booking.experience.name,
+              description: `Experience booking for ${booking.numParticipants} participant${booking.numParticipants === 1 ? '' : 's'}`,
+            },
+            unit_amount: Math.round(booking.totalPrice * 100),
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: {
+        experienceBookingId: booking._id.toString(),
+        userId,
+      },
+      payment_intent_data: {
+        metadata: {
+          experienceBookingId: booking._id.toString(),
+          userId,
+        },
+      },
+      mode: 'payment',
+      success_url: `${baseUrl}/experiences/confirmation/${booking._id}?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${baseUrl}/experiences/confirmation/${booking._id}`,
+    });
+
+    await ExperienceBooking.findByIdAndUpdate(bookingId, {
+      stripeSessionId: session.id,
+    });
+
+    const response: ApiResponse<{ url: string }> = {
+      success: true,
+      data: { url: session.url! },
+    };
+
+    return NextResponse.json(response);
+  } catch (error) {
+    console.error('Error creating experience checkout session:', error);
+    const response: ApiResponse<never> = {
+      success: false,
+      error: 'Failed to create checkout session',
+    };
+    return NextResponse.json(response, { status: 500 });
+  }
+}

--- a/app/api/payments/webhook/route.ts
+++ b/app/api/payments/webhook/route.ts
@@ -1,6 +1,20 @@
-import { Booking, ProcessedStripeEvent, connectDB } from '@/models';
-import { sendPaymentConfirmationEmail } from '@/lib/email';
-import type { PopulatedBooking } from '@/types';
+import {
+  Booking,
+  DiningReservation,
+  ExperienceBooking,
+  ProcessedStripeEvent,
+  connectDB,
+} from '@/models';
+import {
+  sendPaymentConfirmationEmail,
+  sendDiningConfirmationEmail,
+  sendExperienceConfirmationEmail,
+} from '@/lib/email';
+import type {
+  PopulatedBooking,
+  PopulatedDiningReservation,
+  PopulatedExperienceBooking,
+} from '@/types';
 import { getStripe } from '@/lib/stripe';
 import { NextRequest, NextResponse } from 'next/server';
 import type Stripe from 'stripe';
@@ -82,6 +96,8 @@ export async function POST(request: NextRequest) {
         const session = event.data.object as Stripe.Checkout.Session;
         const bookingId = session.metadata?.bookingId;
         const isDeposit = session.metadata?.isDeposit === 'true';
+        const diningReservationId = session.metadata?.diningReservationId;
+        const experienceBookingId = session.metadata?.experienceBookingId;
 
         if (bookingId) {
           const booking = (await Booking.findById(bookingId).populate(
@@ -141,6 +157,86 @@ export async function POST(request: NextRequest) {
               );
             }
           }
+        } else if (diningReservationId) {
+          const reservation = (await DiningReservation.findById(
+            diningReservationId
+          ).populate('dining')) as unknown as PopulatedDiningReservation | null;
+
+          if (!reservation) {
+            console.error(
+              `Dining reservation not found: ${diningReservationId}`
+            );
+            break;
+          }
+
+          if (reservation.isPaid) {
+            break;
+          }
+
+          await DiningReservation.findByIdAndUpdate(diningReservationId, {
+            stripePaymentIntentId: session.payment_intent as string,
+            stripeSessionId: session.id,
+            paidAt: new Date(),
+            status: 'confirmed',
+            isPaid: true,
+          });
+
+          if (!reservation.paymentConfirmationSentAt) {
+            const emailResult = await sendDiningConfirmationEmail({
+              reservation,
+            });
+            if (emailResult.success) {
+              await DiningReservation.findByIdAndUpdate(diningReservationId, {
+                paymentConfirmationSentAt: new Date(),
+              });
+            } else {
+              console.error(
+                'Failed to send dining confirmation email:',
+                emailResult.error
+              );
+            }
+          }
+        } else if (experienceBookingId) {
+          const booking = (await ExperienceBooking.findById(
+            experienceBookingId
+          ).populate(
+            'experience'
+          )) as unknown as PopulatedExperienceBooking | null;
+
+          if (!booking) {
+            console.error(
+              `Experience booking not found: ${experienceBookingId}`
+            );
+            break;
+          }
+
+          if (booking.isPaid) {
+            break;
+          }
+
+          await ExperienceBooking.findByIdAndUpdate(experienceBookingId, {
+            stripePaymentIntentId: session.payment_intent as string,
+            stripeSessionId: session.id,
+            paidAt: new Date(),
+            status: 'confirmed',
+            isPaid: true,
+          });
+
+          if (!booking.paymentConfirmationSentAt) {
+            const emailResult = await sendExperienceConfirmationEmail({
+              booking,
+            });
+            if (emailResult.success) {
+              await ExperienceBooking.findByIdAndUpdate(experienceBookingId, {
+                paymentConfirmationSentAt: new Date(),
+              });
+            } else {
+              console.error(
+                'Failed to send experience confirmation email:',
+                emailResult.error
+              );
+            }
+          }
         }
         break;
       }
@@ -148,6 +244,8 @@ export async function POST(request: NextRequest) {
       case 'payment_intent.succeeded': {
         const paymentIntent = event.data.object as Stripe.PaymentIntent;
         const bookingId = paymentIntent.metadata?.bookingId;
+        const diningReservationId = paymentIntent.metadata?.diningReservationId;
+        const experienceBookingId = paymentIntent.metadata?.experienceBookingId;
 
         if (bookingId) {
           const booking = await Booking.findById(bookingId);
@@ -155,10 +253,35 @@ export async function POST(request: NextRequest) {
             console.error(`Booking not found: ${bookingId}`);
             break;
           }
-
-          // Only update if not already set
           if (!booking.stripePaymentIntentId) {
             await Booking.findByIdAndUpdate(bookingId, {
+              stripePaymentIntentId: paymentIntent.id,
+            });
+          }
+        } else if (diningReservationId) {
+          const reservation =
+            await DiningReservation.findById(diningReservationId);
+          if (!reservation) {
+            console.error(
+              `Dining reservation not found: ${diningReservationId}`
+            );
+            break;
+          }
+          if (!reservation.stripePaymentIntentId) {
+            await DiningReservation.findByIdAndUpdate(diningReservationId, {
+              stripePaymentIntentId: paymentIntent.id,
+            });
+          }
+        } else if (experienceBookingId) {
+          const booking = await ExperienceBooking.findById(experienceBookingId);
+          if (!booking) {
+            console.error(
+              `Experience booking not found: ${experienceBookingId}`
+            );
+            break;
+          }
+          if (!booking.stripePaymentIntentId) {
+            await ExperienceBooking.findByIdAndUpdate(experienceBookingId, {
               stripePaymentIntentId: paymentIntent.id,
             });
           }

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -421,8 +421,8 @@ export default function BookingsPage() {
                               <div className='pt-2'>
                                 <PaymentButton
                                   amount={amountToPay}
-                                  bookingId={booking._id.toString()}
                                   isDeposit={isDepositDue}
+                                  resourceId={booking._id.toString()}
                                   size='sm'
                                 />
                               </div>

--- a/app/bookings/page.tsx
+++ b/app/bookings/page.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import { Button } from '@heroui/button';
 import { Card, CardBody, CardHeader } from '@heroui/card';
 import { Chip } from '@heroui/chip';
-import { DatePicker } from '@heroui/date-picker';
 import { Input } from '@heroui/input';
 import {
   Modal,
@@ -37,7 +36,7 @@ import {
   useCancelExperienceBooking,
   useExperienceBookingHistory,
 } from '@/hooks/useExperienceBooking';
-import type { Booking, ExperienceBooking } from '@/types';
+import type { Booking } from '@/types';
 
 const statusFilters = [
   { key: 'all', label: 'All Bookings' },

--- a/app/cabins/confirmation/[id]/page.tsx
+++ b/app/cabins/confirmation/[id]/page.tsx
@@ -414,8 +414,8 @@ export default function BookingConfirmationPage({
                 </p>
                 <PaymentButton
                   amount={amountToPay}
-                  bookingId={booking._id}
                   isDeposit={isDepositDue}
+                  resourceId={booking._id}
                   size='lg'
                 />
               </CardBody>

--- a/app/dining/confirmation/[id]/page.tsx
+++ b/app/dining/confirmation/[id]/page.tsx
@@ -19,6 +19,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { title, subtitle } from '@/components/primitives';
+import PaymentButton from '@/components/PaymentButton';
 
 type Params = Promise<{ id: string }>;
 
@@ -91,6 +92,22 @@ export default function DiningConfirmationPage({ params }: { params: Params }) {
     fetchReservation();
   }, [reservationId, isLoaded]);
 
+  useEffect(() => {
+    const onFocus = () => {
+      if (!reservationId) return;
+      fetch(`/api/dining-reservations/${reservationId}`)
+        .then(r => r.json())
+        .then(data => {
+          if (data?.success && data?.data) setReservation(data.data);
+        })
+        .catch(() => {
+          // ignore — user can refresh manually
+        });
+    };
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [reservationId]);
+
   if (isLoading || !isLoaded) {
     return (
       <div className='flex flex-col justify-center items-center min-h-screen gap-4'>
@@ -162,15 +179,25 @@ export default function DiningConfirmationPage({ params }: { params: Params }) {
     <div className='container mx-auto px-4 py-8 max-w-4xl'>
       {/* Success Header */}
       <div className='flex flex-col items-center gap-4 mb-8 text-center'>
-        <CheckCircle className='w-20 h-20 text-success' />
-        <h1 className={title({ size: 'lg' })}>Reservation Submitted!</h1>
+        <CheckCircle
+          className={`w-20 h-20 ${reservation.isPaid ? 'text-success' : 'text-warning'}`}
+        />
+        <h1 className={title({ size: 'lg' })}>
+          {reservation.isPaid
+            ? 'Reservation Confirmed!'
+            : 'Reservation Submitted'}
+        </h1>
         <p className={subtitle()}>
-          Your dining reservation has been received. We'll confirm it shortly.
+          {reservation.isPaid
+            ? "We've sent a confirmation email with your reservation details."
+            : 'Complete payment below to confirm your reservation.'}
         </p>
-        <Chip color='warning' size='lg' variant='flat'>
-          Status:{' '}
-          {reservation.status.charAt(0).toUpperCase() +
-            reservation.status.slice(1)}
+        <Chip
+          color={reservation.isPaid ? 'success' : 'warning'}
+          size='lg'
+          variant='flat'
+        >
+          Status: {reservation.isPaid ? 'Paid' : 'Awaiting payment'}
         </Chip>
       </div>
 
@@ -312,6 +339,14 @@ export default function DiningConfirmationPage({ params }: { params: Params }) {
 
       {/* Action Buttons */}
       <div className='flex flex-col sm:flex-row gap-4 justify-center'>
+        {!reservation.isPaid && (
+          <PaymentButton
+            amount={reservation.totalPrice}
+            resourceId={reservation._id}
+            resourceType='dining'
+            size='lg'
+          />
+        )}
         <Link href='/bookings'>
           <Button
             color='primary'

--- a/app/experiences/confirmation/[id]/page.tsx
+++ b/app/experiences/confirmation/[id]/page.tsx
@@ -19,6 +19,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { title, subtitle } from '@/components/primitives';
+import PaymentButton from '@/components/PaymentButton';
 
 type Params = Promise<{ id: string }>;
 
@@ -88,6 +89,22 @@ export default function ExperienceConfirmationPage({
     fetchBooking();
   }, [bookingId, isLoaded]);
 
+  useEffect(() => {
+    const onFocus = () => {
+      if (!bookingId) return;
+      fetch(`/api/experience-bookings/${bookingId}`)
+        .then(r => r.json())
+        .then(data => {
+          if (data?.success && data?.data) setBooking(data.data);
+        })
+        .catch(() => {
+          // ignore — user can refresh manually
+        });
+    };
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [bookingId]);
+
   if (isLoading || !isLoaded) {
     return (
       <div className='flex flex-col justify-center items-center min-h-screen gap-4'>
@@ -152,14 +169,23 @@ export default function ExperienceConfirmationPage({
     <div className='container mx-auto px-4 py-8 max-w-4xl'>
       {/* Success Header */}
       <div className='flex flex-col items-center gap-4 mb-8 text-center'>
-        <CheckCircle className='w-20 h-20 text-success' />
-        <h1 className={title({ size: 'lg' })}>Booking Submitted!</h1>
+        <CheckCircle
+          className={`w-20 h-20 ${booking.isPaid ? 'text-success' : 'text-warning'}`}
+        />
+        <h1 className={title({ size: 'lg' })}>
+          {booking.isPaid ? 'Booking Confirmed!' : 'Booking Submitted'}
+        </h1>
         <p className={subtitle()}>
-          Your experience booking has been received. We'll confirm it shortly.
+          {booking.isPaid
+            ? "We've sent a confirmation email with your booking details."
+            : 'Complete payment below to confirm your booking.'}
         </p>
-        <Chip color='warning' size='lg' variant='flat'>
-          Status:{' '}
-          {booking.status.charAt(0).toUpperCase() + booking.status.slice(1)}
+        <Chip
+          color={booking.isPaid ? 'success' : 'warning'}
+          size='lg'
+          variant='flat'
+        >
+          Status: {booking.isPaid ? 'Paid' : 'Awaiting payment'}
         </Chip>
       </div>
 
@@ -279,6 +305,14 @@ export default function ExperienceConfirmationPage({
 
       {/* Action Buttons */}
       <div className='flex flex-col sm:flex-row gap-4 justify-center'>
+        {!booking.isPaid && (
+          <PaymentButton
+            amount={booking.totalPrice}
+            resourceId={booking._id}
+            resourceType='experience'
+            size='lg'
+          />
+        )}
         <Link href='/bookings'>
           <Button
             color='primary'

--- a/components/PaymentButton.tsx
+++ b/components/PaymentButton.tsx
@@ -4,28 +4,45 @@ import { Button } from '@heroui/button';
 import { addToast } from '@heroui/toast';
 import { CreditCard } from 'lucide-react';
 
-import { useCreateCheckoutSession } from '@/hooks/usePayment';
+import {
+  useCreateCheckoutSession,
+  useCreateDiningCheckoutSession,
+  useCreateExperienceCheckoutSession,
+} from '@/hooks/usePayment';
+
+type ResourceType = 'cabin' | 'dining' | 'experience';
 
 interface PaymentButtonProps {
-  bookingId: string;
+  resourceId: string;
   amount: number;
+  resourceType?: ResourceType;
   isDeposit?: boolean;
   size?: 'sm' | 'md' | 'lg';
   className?: string;
 }
 
 export default function PaymentButton({
-  bookingId,
+  resourceId,
   amount,
+  resourceType = 'cabin',
   isDeposit = false,
   size = 'md',
   className,
 }: PaymentButtonProps) {
-  const createCheckout = useCreateCheckoutSession();
+  const cabinCheckout = useCreateCheckoutSession();
+  const diningCheckout = useCreateDiningCheckoutSession();
+  const experienceCheckout = useCreateExperienceCheckoutSession();
+
+  const mutation =
+    resourceType === 'dining'
+      ? diningCheckout
+      : resourceType === 'experience'
+        ? experienceCheckout
+        : cabinCheckout;
 
   const handlePayment = async () => {
     try {
-      const { url } = await createCheckout.mutateAsync(bookingId);
+      const { url } = await mutation.mutateAsync(resourceId);
       window.location.href = url;
     } catch (error) {
       addToast({
@@ -43,11 +60,9 @@ export default function PaymentButton({
     <Button
       className={className}
       color='success'
-      isLoading={createCheckout.isPending}
+      isLoading={mutation.isPending}
       size={size}
-      startContent={
-        !createCheckout.isPending && <CreditCard className='w-4 h-4' />
-      }
+      startContent={!mutation.isPending && <CreditCard className='w-4 h-4' />}
       onPress={handlePayment}
     >
       {isDeposit ? `Pay Deposit ($${amount})` : `Pay Now ($${amount})`}

--- a/hooks/usePayment.ts
+++ b/hooks/usePayment.ts
@@ -63,3 +63,65 @@ export const usePaymentStatus = (bookingId: string) => {
     gcTime: 10 * 60 * 1000,
   });
 };
+
+/**
+ * Hook to create a Stripe Checkout session for a dining reservation
+ */
+export const useCreateDiningCheckoutSession = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (reservationId: string): Promise<{ url: string }> => {
+      const response = await fetch('/api/payments/create-dining-checkout', {
+        body: JSON.stringify({ reservationId }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to create checkout session');
+      }
+
+      const data: ApiResponse<{ url: string }> = await response.json();
+      return data.data!;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['dining-reservation'] });
+      queryClient.invalidateQueries({
+        queryKey: ['dining-reservations-history'],
+      });
+    },
+  });
+};
+
+/**
+ * Hook to create a Stripe Checkout session for an experience booking
+ */
+export const useCreateExperienceCheckoutSession = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (bookingId: string): Promise<{ url: string }> => {
+      const response = await fetch('/api/payments/create-experience-checkout', {
+        body: JSON.stringify({ bookingId }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to create checkout session');
+      }
+
+      const data: ApiResponse<{ url: string }> = await response.json();
+      return data.data!;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['experience-booking'] });
+      queryClient.invalidateQueries({
+        queryKey: ['experience-bookings-history'],
+      });
+    },
+  });
+};

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -1,8 +1,17 @@
 import { Resend } from 'resend';
 import { clerkClient } from '@clerk/nextjs/server';
 
-import { PaymentConfirmationEmail } from '@/components/EmailTemplates';
-import type { PopulatedBooking, Cabin } from '@/types';
+import {
+  PaymentConfirmationEmail,
+  DiningReservationConfirmationEmail,
+  ExperienceBookingConfirmationEmail,
+} from '@/components/EmailTemplates';
+import type {
+  PopulatedBooking,
+  Cabin,
+  PopulatedDiningReservation,
+  PopulatedExperienceBooking,
+} from '@/types';
 
 const resend = new Resend(process.env.RESEND_API_KEY);
 
@@ -167,6 +176,114 @@ export async function sendCancellationConfirmationEmail(
     };
   } catch (error) {
     console.error('Failed to send cancellation confirmation email:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to send email',
+    };
+  }
+}
+
+export interface SendDiningConfirmationParams {
+  reservation: PopulatedDiningReservation;
+}
+
+export async function sendDiningConfirmationEmail(
+  params: SendDiningConfirmationParams
+): Promise<EmailResult> {
+  const { reservation } = params;
+
+  try {
+    const clerk = await clerkClient();
+    const user = await clerk.users.getUser(reservation.customer as string);
+
+    const email = user.emailAddresses?.[0]?.emailAddress;
+    const firstName = user.firstName || 'Guest';
+
+    if (!email || !validateEmail(email)) {
+      return {
+        success: false,
+        error: 'Invalid or missing email address for customer',
+      };
+    }
+
+    const { data, error } = await resend.emails.send({
+      from: 'LodgeFlow <onboarding@resend.dev>',
+      to: email,
+      subject: `Reservation Confirmed - ${reservation.dining.name}`,
+      react: DiningReservationConfirmationEmail({
+        date: reservation.date.toString(),
+        diningData: reservation.dining,
+        firstName,
+        numGuests: reservation.numGuests,
+        occasion: reservation.occasion,
+        reservationId: reservation._id.toString(),
+        tablePreference: reservation.tablePreference,
+        time: reservation.time,
+        totalPrice: reservation.totalPrice,
+      }),
+    });
+
+    if (error) {
+      console.error('Resend email error:', error);
+      return { success: false, error: error.message };
+    }
+
+    return { success: true, messageId: data?.id };
+  } catch (error) {
+    console.error('Failed to send dining confirmation email:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to send email',
+    };
+  }
+}
+
+export interface SendExperienceConfirmationParams {
+  booking: PopulatedExperienceBooking;
+}
+
+export async function sendExperienceConfirmationEmail(
+  params: SendExperienceConfirmationParams
+): Promise<EmailResult> {
+  const { booking } = params;
+
+  try {
+    const clerk = await clerkClient();
+    const user = await clerk.users.getUser(booking.customer as string);
+
+    const email = user.emailAddresses?.[0]?.emailAddress;
+    const firstName = user.firstName || 'Guest';
+
+    if (!email || !validateEmail(email)) {
+      return {
+        success: false,
+        error: 'Invalid or missing email address for customer',
+      };
+    }
+
+    const { data, error } = await resend.emails.send({
+      from: 'LodgeFlow <onboarding@resend.dev>',
+      to: email,
+      subject: `Booking Confirmed - ${booking.experience.name}`,
+      react: ExperienceBookingConfirmationEmail({
+        bookingId: booking._id.toString(),
+        date: booking.date.toString(),
+        experienceData: booking.experience,
+        firstName,
+        numParticipants: booking.numParticipants,
+        timeSlot: booking.timeSlot,
+        totalPrice: booking.totalPrice,
+      }),
+    });
+
+    if (error) {
+      console.error('Resend email error:', error);
+      return { success: false, error: error.message };
+    }
+
+    return { success: true, messageId: data?.id };
+  } catch (error) {
+    console.error('Failed to send experience confirmation email:', error);
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Failed to send email',

--- a/models/DiningReservation.ts
+++ b/models/DiningReservation.ts
@@ -10,6 +10,9 @@ export interface IDiningReservation extends Document {
   totalPrice: number;
   isPaid: boolean;
   stripePaymentIntentId?: string;
+  stripeSessionId?: string;
+  paidAt?: Date;
+  paymentConfirmationSentAt?: Date;
   dietaryRequirements?: string[];
   specialRequests?: string[];
   tablePreference?: 'indoor' | 'outdoor' | 'bar' | 'no-preference';
@@ -59,6 +62,15 @@ const DiningReservationSchema: Schema = new Schema(
     },
     stripePaymentIntentId: {
       type: String,
+    },
+    stripeSessionId: {
+      type: String,
+    },
+    paidAt: {
+      type: Date,
+    },
+    paymentConfirmationSentAt: {
+      type: Date,
     },
     dietaryRequirements: {
       type: [String],

--- a/models/ExperienceBooking.ts
+++ b/models/ExperienceBooking.ts
@@ -10,6 +10,9 @@ export interface IExperienceBooking extends Document {
   totalPrice: number;
   isPaid: boolean;
   stripePaymentIntentId?: string;
+  stripeSessionId?: string;
+  paidAt?: Date;
+  paymentConfirmationSentAt?: Date;
   specialRequests?: string[];
   observations?: string;
   createdAt: Date;
@@ -55,6 +58,15 @@ const ExperienceBookingSchema: Schema = new Schema(
     },
     stripePaymentIntentId: {
       type: String,
+    },
+    stripeSessionId: {
+      type: String,
+    },
+    paidAt: {
+      type: Date,
+    },
+    paymentConfirmationSentAt: {
+      type: Date,
     },
     specialRequests: {
       type: [String],


### PR DESCRIPTION
Closes #67. Closes #68.

## Summary

Wires Stripe Checkout end-to-end for dining reservations and experience bookings. Mirrors the existing cabin-booking payment flow exactly — both resources now have a "Pay Now" button on their confirmation page that redirects to Stripe and a webhook handler that marks them paid + emails the customer.

## How it works

1. The reservation/booking form creates an unpaid resource (existing behavior, unchanged)
2. The user lands on the confirmation page; if `!isPaid`, a `PaymentButton` is shown
3. Clicking it POSTs to a new resource-specific checkout endpoint, which creates a Stripe Checkout Session with `metadata.diningReservationId` (or `metadata.experienceBookingId`) and returns the session URL
4. The browser redirects to Stripe; success and cancel URLs both point back to the same confirmation page
5. On payment success, the existing webhook (extended in this PR) sets `isPaid: true`, `status: 'confirmed'`, `paidAt`, `stripePaymentIntentId`, and sends a confirmation email
6. The confirmation page has a window-focus listener that re-fetches state, so the user sees the paid state once they return from Stripe

## Files

- New: `app/api/payments/create-dining-checkout/route.ts`, `app/api/payments/create-experience-checkout/route.ts`
- New: hook tests in `__tests__/bookings/usePaymentDiningExperience.test.tsx`
- Modified: `models/DiningReservation.ts`, `models/ExperienceBooking.ts` — add `stripeSessionId`, `paidAt`, `paymentConfirmationSentAt`
- Modified: `app/api/payments/webhook/route.ts` — extend `checkout.session.completed` and `payment_intent.succeeded` cases for the two new metadata keys
- Modified: `lib/email.ts` — add `sendDiningConfirmationEmail`, `sendExperienceConfirmationEmail`
- Modified: `hooks/usePayment.ts` — add `useCreateDiningCheckoutSession`, `useCreateExperienceCheckoutSession`
- Modified: `components/PaymentButton.tsx` — accept `resourceType` prop; rename `bookingId` → `resourceId`
- Modified: `app/dining/confirmation/[id]/page.tsx`, `app/experiences/confirmation/[id]/page.tsx` — render PaymentButton when unpaid; refresh on window focus
- Modified: `app/cabins/confirmation/[id]/page.tsx`, `app/bookings/page.tsx` — rename PaymentButton prop (and remove dead imports as a small chore)

## Out of scope

- Refunds for dining/experience cancellations (separate issue if needed)
- API-handler test infrastructure (deferred to #69, which will set up the right scaffolding)

## CI note

`pnpm ci:check` may show prettier failures for `.github/workflows/claude-code-review.yml` and `.github/workflows/claude.yml`. These files are already malformatted on `main` and are NOT introduced by this branch (verified by checking out main's copy of each — same flags). Ignored here to keep the PR focused; will need a separate format-fix PR.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm exec jest` passes — 18 suites, 125 tests (4 new)
- [ ] **Manual (reviewer):** dining payment flow works end-to-end with Stripe test card `4242 4242 4242 4242`
- [ ] **Manual (reviewer):** experience payment flow works end-to-end
- [ ] **Manual (reviewer):** cancel path returns to confirmation page in unpaid state
- [ ] **Manual (reviewer):** existing cabin payment flow still works (PaymentButton refactor regression check)
- [ ] **Manual (reviewer):** webhook receives `checkout.session.completed`, marks resource paid, sends email, sets `paymentConfirmationSentAt` to prevent duplicate emails

## Manual smoke test — how to run locally

```bash
# Terminal A
pnpm dev

# Terminal B
stripe listen --forward-to localhost:3002/api/payments/webhook
```

Copy the `whsec_...` from `stripe listen` into `.env.local` as `STRIPE_WEBHOOK_SECRET` if not already set, then restart `pnpm dev`. Pay with test card `4242 4242 4242 4242`, any future expiry, any CVC.