### PR TITLE
Fix high-risk security vulnerabilities and performance issues

### DIFF
--- a/app/api/bookings/[id]/refund-estimate/route.ts
+++ b/app/api/bookings/[id]/refund-estimate/route.ts
@@ -42,11 +42,11 @@ export async function GET(
       );
     }
 
-    // Verify ownership
+    // Verify ownership — 404 (not 403) so we don't leak that the booking exists
     if (booking.customer !== userId) {
       return NextResponse.json(
-        { success: false, error: 'Not authorized to view this booking' },
-        { status: 403 }
+        { success: false, error: 'Booking not found' },
+        { status: 404 }
       );
     }
 

--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -226,6 +226,32 @@ export async function DELETE(
       return NextResponse.json(response, { status: 400 });
     }
 
+    // Atomically claim the cancellation BEFORE issuing any refund. Two
+    // concurrent DELETE requests could both pass the status check above and
+    // each trigger a Stripe refund; this conditional update guarantees only
+    // one request proceeds to the refund step.
+    const claimedBooking = await Booking.findOneAndUpdate(
+      {
+        _id: id,
+        customer: userId,
+        status: { $nin: ['checked-in', 'checked-out', 'cancelled'] },
+      },
+      {
+        status: 'cancelled',
+        cancelledAt: new Date(),
+        cancellationReason,
+      },
+      { new: true }
+    );
+
+    if (!claimedBooking) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Booking has already been cancelled or cannot be cancelled',
+      };
+      return NextResponse.json(response, { status: 409 });
+    }
+
     // Get settings for cancellation policy
     const settings = await Settings.getSettings();
 
@@ -271,11 +297,8 @@ export async function DELETE(
       }
     }
 
-    // Update booking with cancellation details
+    // Record refund outcome (status/cancelledAt were set by the atomic claim)
     const updateData = {
-      status: 'cancelled',
-      cancelledAt: new Date(),
-      cancellationReason,
       refundStatus,
       refundAmount: refundEstimate.refundAmount,
     };

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,12 +1,21 @@
 import { Booking, Cabin, connectDB, Settings } from '@/models';
 import type { ApiResponse, PopulatedBooking } from '@/types';
 import { auth } from '@clerk/nextjs/server';
+import mongoose from 'mongoose';
 import { NextRequest, NextResponse } from 'next/server';
 import { createBookingSchema } from '@/lib/validations';
 import {
   validateRequest,
   validationErrorResponse,
 } from '@/lib/validations/utils';
+
+class BookingConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BookingConflictError';
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const { userId } = await auth();
@@ -153,29 +162,76 @@ export async function POST(request: NextRequest) {
       ? Math.round(totalPrice * (settings.depositPercentage / 100))
       : 0;
 
-    // Create booking
-    const booking = await Booking.create({
-      cabin: cabinId,
-      customer: userId,
-      checkInDate: checkIn,
-      checkOutDate: checkOut,
-      numNights,
-      numGuests,
-      status: 'unconfirmed',
-      cabinPrice: effectivePrice,
-      extrasPrice,
-      totalPrice,
-      isPaid: false,
-      paymentMethod: 'online',
-      extras: bookingExtras,
-      specialRequests,
-      observations,
-      depositPaid: false,
-      depositAmount,
-    });
+    // Create the booking and re-verify no overlap inside a transaction.
+    // The findOverlapping pre-check above is a fast path, but two concurrent
+    // requests can both pass it (check-then-insert race) and double-book the
+    // cabin. Same pattern as the dining reservation create route.
+    const session = await mongoose.startSession();
+    let bookingId: string;
+
+    try {
+      await session.withTransaction(async () => {
+        const [created] = await Booking.create(
+          [
+            {
+              cabin: cabinId,
+              customer: userId,
+              checkInDate: checkIn,
+              checkOutDate: checkOut,
+              numNights,
+              numGuests,
+              status: 'unconfirmed',
+              cabinPrice: effectivePrice,
+              extrasPrice,
+              totalPrice,
+              isPaid: false,
+              paymentMethod: 'online',
+              extras: bookingExtras,
+              specialRequests,
+              observations,
+              depositPaid: false,
+              depositAmount,
+            },
+          ],
+          { session }
+        );
+
+        bookingId = created._id.toString();
+
+        const conflicts = await Booking.find(
+          {
+            _id: { $ne: created._id },
+            cabin: cabinId,
+            status: { $ne: 'cancelled' },
+            checkInDate: { $lt: checkOut },
+            checkOutDate: { $gt: checkIn },
+          },
+          null,
+          { session }
+        );
+
+        if (conflicts.length > 0) {
+          throw new BookingConflictError(
+            'Cabin is not available for the selected dates'
+          );
+        }
+      });
+    } catch (err) {
+      session.endSession();
+      if (err instanceof BookingConflictError) {
+        const response: ApiResponse<never> = {
+          success: false,
+          error: err.message,
+        };
+        return NextResponse.json(response, { status: 409 });
+      }
+      throw err;
+    }
+
+    session.endSession();
 
     // Populate the booking for response
-    const populatedBooking = (await Booking.findById(booking._id).populate(
+    const populatedBooking = (await Booking.findById(bookingId!).populate(
       'cabin'
     )) as unknown as PopulatedBooking;
     const response: ApiResponse<any> = {

--- a/app/api/cabins/availability/route.ts
+++ b/app/api/cabins/availability/route.ts
@@ -1,61 +1,68 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
 import { connectDB, Booking, Cabin } from '@/models';
-import type { ApiResponse, AvailableCabin, AvailabilityQuery } from '@/types';
+import type { ApiResponse, AvailableCabin } from '@/types';
+import {
+  validateRequest,
+  validationErrorResponse,
+} from '@/lib/validations/utils';
+
+const availabilityQuerySchema = z
+  .object({
+    checkInDate: z.coerce.date(),
+    checkOutDate: z.coerce.date(),
+    guests: z.coerce.number().int().min(1).max(50),
+  })
+  .refine(data => data.checkOutDate > data.checkInDate, {
+    message: 'Check-out date must be after check-in date',
+    path: ['checkOutDate'],
+  });
 
 export async function POST(request: NextRequest) {
   try {
     await connectDB();
 
-    const body: AvailabilityQuery = await request.json();
-    const { checkInDate, checkOutDate, guests } = body;
+    const body = await request.json();
 
-    if (!checkInDate || !checkOutDate || !guests) {
-      const response: ApiResponse<never> = {
-        success: false,
-        error: 'Missing required fields: checkInDate, checkOutDate, guests',
-      };
-      return NextResponse.json(response, { status: 400 });
+    const validation = validateRequest(availabilityQuerySchema, body);
+    if (!validation.success) {
+      return validationErrorResponse(validation.error);
     }
 
-    const checkIn = new Date(checkInDate);
-    const checkOut = new Date(checkOutDate);
-
-    if (checkIn >= checkOut) {
-      const response: ApiResponse<never> = {
-        success: false,
-        error: 'Check-out date must be after check-in date',
-      };
-      return NextResponse.json(response, { status: 400 });
-    }
+    const {
+      checkInDate: checkIn,
+      checkOutDate: checkOut,
+      guests,
+    } = validation.data;
 
     // Find cabins that can accommodate the guests
-    const cabins = await Cabin.find({ capacity: { $gte: guests } }).sort({
-      price: 1,
-    });
+    const cabins = await Cabin.find({
+      status: 'active',
+      capacity: { $gte: guests },
+    }).sort({ price: 1 });
 
-    // Check availability for each cabin
-    const availabilityPromises = cabins.map(async cabin => {
-      const conflictingBookings = await Booking.find({
-        cabin: cabin._id,
-        status: { $nin: ['cancelled'] },
-        $or: [
-          {
-            checkInDate: { $lt: checkOut },
-            checkOutDate: { $gt: checkIn },
-          },
-        ],
-      });
+    // Fetch all overlapping bookings for these cabins in a single query
+    // instead of one query per cabin.
+    const overlappingBookings = await Booking.find({
+      cabin: { $in: cabins.map(cabin => cabin._id) },
+      status: { $nin: ['cancelled'] },
+      checkInDate: { $lt: checkOut },
+      checkOutDate: { $gt: checkIn },
+    })
+      .select('cabin')
+      .lean();
 
-      const availableCabin: AvailableCabin = {
-        ...cabin.toObject(),
-        isAvailable: conflictingBookings.length === 0,
-        conflictingBookings: conflictingBookings.map(b => b._id.toString()),
-      };
+    const bookedCabinIds = new Set(
+      overlappingBookings.map(booking => String(booking.cabin))
+    );
 
-      return availableCabin;
-    });
-
-    const availableCabins = await Promise.all(availabilityPromises);
+    // Note: booking IDs of conflicting reservations are intentionally not
+    // returned — this is a public endpoint and those belong to other users.
+    const availableCabins: AvailableCabin[] = cabins.map(cabin => ({
+      ...cabin.toObject(),
+      isAvailable: !bookedCabinIds.has(cabin._id.toString()),
+    }));
 
     const response: ApiResponse<AvailableCabin[]> = {
       success: true,

--- a/app/api/cabins/route.ts
+++ b/app/api/cabins/route.ts
@@ -4,6 +4,7 @@ import { connectDB, Cabin } from '@/models';
 import type { ApiResponse, Cabin as CabinType } from '@/types';
 import { cabinQuerySchema } from '@/lib/validations';
 import {
+  escapeRegex,
   validateRequest,
   validationErrorResponse,
 } from '@/lib/validations/utils';
@@ -38,12 +39,13 @@ export async function GET(request: NextRequest) {
       if (maxPrice) query.price.$lte = maxPrice;
     }
 
-    // Text search functionality
+    // Text search functionality — escape user input before building the regex
     if (search) {
+      const safeSearch = escapeRegex(search);
       query.$or = [
-        { name: { $regex: search, $options: 'i' } },
-        { description: { $regex: search, $options: 'i' } },
-        { amenities: { $regex: search, $options: 'i' } },
+        { name: { $regex: safeSearch, $options: 'i' } },
+        { description: { $regex: safeSearch, $options: 'i' } },
+        { amenities: { $regex: safeSearch, $options: 'i' } },
       ];
     }
 

--- a/app/api/dining/route.ts
+++ b/app/api/dining/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { connectDB, Dining } from '@/models';
 import { diningQuerySchema } from '@/lib/validations';
 import {
+  escapeRegex,
   validateRequest,
   validationErrorResponse,
 } from '@/lib/validations/utils';
@@ -65,12 +66,13 @@ export async function GET(request: Request) {
       query.dietary = { $in: dietaryArray };
     }
 
-    // Text search functionality
+    // Text search functionality — escape user input before building the regex
     if (search) {
+      const safeSearch = escapeRegex(search);
       query.$or = [
-        { name: { $regex: search, $options: 'i' } },
-        { description: { $regex: search, $options: 'i' } },
-        { dietary: { $regex: search, $options: 'i' } },
+        { name: { $regex: safeSearch, $options: 'i' } },
+        { description: { $regex: safeSearch, $options: 'i' } },
+        { dietary: { $regex: safeSearch, $options: 'i' } },
       ];
     }
 

--- a/app/api/experience-bookings/[id]/route.ts
+++ b/app/api/experience-bookings/[id]/route.ts
@@ -1,8 +1,13 @@
 import { auth } from '@clerk/nextjs/server';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { connectDB, ExperienceBooking } from '@/models';
+import { connectDB, Experience, ExperienceBooking } from '@/models';
 import type { ApiResponse } from '@/types';
+import { updateExperienceBookingDetailsSchema } from '@/lib/validations';
+import {
+  validateRequest,
+  validationErrorResponse,
+} from '@/lib/validations/utils';
 
 type Params = Promise<{ id: string }>;
 
@@ -100,26 +105,85 @@ export async function PATCH(
       return NextResponse.json(response, { status: 400 });
     }
 
-    const updates = await request.json();
-    const allowedFields = [
-      'date',
-      'timeSlot',
-      'numParticipants',
-      'specialRequests',
-      'observations',
-    ];
+    const body = await request.json();
 
-    const filteredUpdates: Record<string, unknown> = {};
-    for (const key of allowedFields) {
-      if (updates[key] !== undefined) {
-        filteredUpdates[key] = updates[key];
+    // Validate request body with Zod
+    const validation = validateRequest(
+      updateExperienceBookingDetailsSchema,
+      body
+    );
+    if (!validation.success) {
+      return validationErrorResponse(validation.error);
+    }
+
+    const filteredUpdates: Record<string, unknown> = { ...validation.data };
+
+    // Load the experience to re-validate capacity and pricing
+    const experience = await Experience.findById(booking.experience);
+    if (!experience) {
+      const response: ApiResponse<never> = {
+        success: false,
+        error: 'Associated experience not found',
+      };
+      return NextResponse.json(response, { status: 404 });
+    }
+
+    const effectiveDate = validation.data.date ?? booking.date;
+    const effectiveParticipants =
+      validation.data.numParticipants ?? booking.numParticipants;
+
+    // Re-check capacity when the date or participant count changes
+    if (
+      experience.maxParticipants &&
+      (validation.data.date || validation.data.numParticipants)
+    ) {
+      if (effectiveParticipants > experience.maxParticipants) {
+        const response: ApiResponse<never> = {
+          success: false,
+          error: `Maximum ${experience.maxParticipants} participants allowed`,
+        };
+        return NextResponse.json(response, { status: 400 });
       }
+
+      const dayStart = new Date(effectiveDate);
+      dayStart.setHours(0, 0, 0, 0);
+      const dayEnd = new Date(effectiveDate);
+      dayEnd.setHours(23, 59, 59, 999);
+
+      const otherBookings = await ExperienceBooking.find({
+        _id: { $ne: id },
+        experience: booking.experience,
+        date: { $gte: dayStart, $lt: dayEnd },
+        status: { $nin: ['cancelled'] },
+      });
+
+      const totalParticipants = otherBookings.reduce(
+        (sum, b) => sum + b.numParticipants,
+        0
+      );
+
+      if (
+        totalParticipants + effectiveParticipants >
+        experience.maxParticipants
+      ) {
+        const remaining = experience.maxParticipants - totalParticipants;
+        const response: ApiResponse<never> = {
+          success: false,
+          error: `Not enough spots available. Only ${Math.max(0, remaining)} spot${remaining !== 1 ? 's' : ''} remaining.`,
+        };
+        return NextResponse.json(response, { status: 409 });
+      }
+    }
+
+    // Recalculate totalPrice when the participant count changes
+    if (validation.data.numParticipants) {
+      filteredUpdates.totalPrice = experience.price * effectiveParticipants;
     }
 
     const updated = await ExperienceBooking.findByIdAndUpdate(
       id,
       filteredUpdates,
-      { new: true }
+      { new: true, runValidators: true }
     ).populate('experience');
 
     const response: ApiResponse<typeof updated> = {

--- a/app/api/payments/webhook/route.ts
+++ b/app/api/payments/webhook/route.ts
@@ -202,7 +202,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ received: true });
   } catch (error) {
     console.error('Webhook processing error:', error);
-    // Don't mark as processed on error so Stripe can retry
+    // Release the idempotency claim so Stripe's retry of this event is
+    // actually processed — otherwise the retry hits the claim and is skipped,
+    // permanently losing the event (e.g. a booking never marked as paid).
+    try {
+      await ProcessedStripeEvent.deleteOne({ eventId: event.id });
+    } catch (releaseError) {
+      console.error(
+        'Failed to release webhook idempotency claim:',
+        releaseError
+      );
+    }
     return NextResponse.json(
       { error: 'Webhook processing failed' },
       { status: 500 }

--- a/app/api/send/confirm/route.ts
+++ b/app/api/send/confirm/route.ts
@@ -64,11 +64,13 @@ export async function POST(request: Request) {
     });
 
     if (error) {
-      return Response.json({ error }, { status: 500 });
+      console.error('Email send failed:', error);
+      return Response.json({ error: 'Failed to send email' }, { status: 500 });
     }
 
     return Response.json(data);
   } catch (error) {
-    return Response.json({ error }, { status: 500 });
+    console.error('Email send failed:', error);
+    return Response.json({ error: 'Failed to send email' }, { status: 500 });
   }
 }

--- a/app/api/send/dining-confirm/route.ts
+++ b/app/api/send/dining-confirm/route.ts
@@ -68,11 +68,13 @@ export async function POST(request: Request) {
     });
 
     if (error) {
-      return Response.json({ error }, { status: 500 });
+      console.error('Email send failed:', error);
+      return Response.json({ error: 'Failed to send email' }, { status: 500 });
     }
 
     return Response.json(data);
   } catch (error) {
-    return Response.json({ error }, { status: 500 });
+    console.error('Email send failed:', error);
+    return Response.json({ error: 'Failed to send email' }, { status: 500 });
   }
 }

--- a/app/api/send/experience-confirm/route.ts
+++ b/app/api/send/experience-confirm/route.ts
@@ -66,11 +66,13 @@ export async function POST(request: Request) {
     });
 
     if (error) {
-      return Response.json({ error }, { status: 500 });
+      console.error('Email send failed:', error);
+      return Response.json({ error: 'Failed to send email' }, { status: 500 });
     }
 
     return Response.json(data);
   } catch (error) {
-    return Response.json({ error }, { status: 500 });
+    console.error('Email send failed:', error);
+    return Response.json({ error: 'Failed to send email' }, { status: 500 });
   }
 }

--- a/app/api/send/payment-confirm/route.ts
+++ b/app/api/send/payment-confirm/route.ts
@@ -73,11 +73,13 @@ export async function POST(request: Request) {
     });
 
     if (error) {
-      return Response.json({ error }, { status: 500 });
+      console.error('Email send failed:', error);
+      return Response.json({ error: 'Failed to send email' }, { status: 500 });
     }
 
     return Response.json(data);
   } catch (error) {
-    return Response.json({ error }, { status: 500 });
+    console.error('Email send failed:', error);
+    return Response.json({ error: 'Failed to send email' }, { status: 500 });
   }
 }

--- a/app/api/send/welcome/route.ts
+++ b/app/api/send/welcome/route.ts
@@ -33,11 +33,13 @@ export async function POST() {
     });
 
     if (error) {
-      return Response.json({ error }, { status: 500 });
+      console.error('Email send failed:', error);
+      return Response.json({ error: 'Failed to send email' }, { status: 500 });
     }
 
     return Response.json(data);
   } catch (error) {
-    return Response.json({ error }, { status: 500 });
+    console.error('Email send failed:', error);
+    return Response.json({ error: 'Failed to send email' }, { status: 500 });
   }
 }

--- a/lib/validations/experience-booking.ts
+++ b/lib/validations/experience-booking.ts
@@ -41,6 +41,34 @@ export const createExperienceBookingSchema = z
   );
 
 /**
+ * Update experience booking details schema (guest-facing PATCH for
+ * /api/experience-bookings/[id]) — the fields a guest may change on their
+ * own booking. Capacity and pricing are re-validated server-side.
+ */
+export const updateExperienceBookingDetailsSchema = z
+  .object({
+    date: z.coerce.date().optional(),
+    timeSlot: z.string().max(50).optional(),
+    numParticipants: z.number().int().min(1).max(500).optional(),
+    specialRequests: z.array(z.string()).optional(),
+    observations: z.string().max(1000).optional(),
+  })
+  .refine(
+    data => {
+      if (!data.date) return true;
+      const now = new Date();
+      now.setHours(0, 0, 0, 0);
+      const bookingDate = new Date(data.date);
+      bookingDate.setHours(0, 0, 0, 0);
+      return bookingDate >= now;
+    },
+    {
+      message: 'Cannot set a date in the past',
+      path: ['date'],
+    }
+  );
+
+/**
  * Update experience booking request schema (guest-facing PATCH)
  */
 export const patchExperienceBookingSchema = z.object({
@@ -55,6 +83,9 @@ export const patchExperienceBookingSchema = z.object({
 
 export type CreateExperienceBookingInput = z.infer<
   typeof createExperienceBookingSchema
+>;
+export type UpdateExperienceBookingDetailsInput = z.infer<
+  typeof updateExperienceBookingDetailsSchema
 >;
 export type PatchExperienceBookingInput = z.infer<
   typeof patchExperienceBookingSchema

--- a/lib/validations/utils.ts
+++ b/lib/validations/utils.ts
@@ -29,6 +29,15 @@ export function validateRequest<T extends z.ZodType>(
 }
 
 /**
+ * Escapes regex metacharacters in user-supplied text before it is used in a
+ * MongoDB $regex query. Without this, input like "(a+)+$" can trigger
+ * catastrophic backtracking (ReDoS) or match unintended documents.
+ */
+export function escapeRegex(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Creates a standardized validation error response
  */
 export function validationErrorResponse(error: string) {

--- a/models/Booking.ts
+++ b/models/Booking.ts
@@ -8,11 +8,7 @@ export interface IBooking extends Document {
   numNights: number;
   numGuests: number;
   status:
-    | 'unconfirmed'
-    | 'confirmed'
-    | 'checked-in'
-    | 'checked-out'
-    | 'cancelled';
+    'unconfirmed' | 'confirmed' | 'checked-in' | 'checked-out' | 'cancelled';
   cabinPrice: number;
   extrasPrice: number;
   totalPrice: number;
@@ -40,12 +36,7 @@ export interface IBooking extends Document {
   cancelledAt?: Date;
   cancellationReason?: string;
   refundStatus?:
-    | 'none'
-    | 'pending'
-    | 'processing'
-    | 'partial'
-    | 'full'
-    | 'failed';
+    'none' | 'pending' | 'processing' | 'partial' | 'full' | 'failed';
   refundAmount?: number;
   refundedAt?: Date;
   paymentConfirmationSentAt?: Date;
@@ -267,6 +258,9 @@ BookingSchema.index({ customer: 1, createdAt: -1 });
 BookingSchema.index({ status: 1, checkInDate: 1 });
 BookingSchema.index({ checkInDate: 1, checkOutDate: 1 });
 BookingSchema.index({ isPaid: 1 });
+// Stripe webhook (charge.refunded) looks bookings up by payment intent —
+// without this index that lookup is a full collection scan.
+BookingSchema.index({ stripePaymentIntentId: 1 }, { sparse: true });
 BookingSchema.index({ checkInDate: 1 });
 BookingSchema.index({ checkOutDate: 1 });
 


### PR DESCRIPTION
Security / correctness:
- Escape user input before building $regex queries in cabin and dining
  search (regex injection / ReDoS on public endpoints)
- Release the Stripe webhook idempotency claim when processing fails, so
  Stripe's retry is not skipped and payment events are never lost
- Atomically claim booking cancellation before issuing a Stripe refund,
  preventing concurrent DELETE requests from double-refunding
- Validate experience-booking PATCH bodies with Zod, re-check capacity,
  and recalculate totalPrice (previously participants/date were accepted
  unvalidated with the old price kept)
- Wrap cabin booking creation in a transaction with an overlap re-check
  to close the check-then-insert double-booking race (same pattern as
  dining reservations)
- Validate the public bulk availability request body and stop returning
  other users' booking IDs; only expose active cabins
- Return 404 instead of 403 on refund-estimate ownership mismatch, per
  the repo convention (403 leaks resource existence)
- Return generic error messages from /api/send routes instead of raw
  error objects

Performance:
- Replace the per-cabin N+1 booking query in POST /api/cabins/availability
  with a single $in query
- Add a sparse index on Booking.stripePaymentIntentId (used by the
  charge.refunded webhook lookup, previously a collection scan)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CDmpigkh9GznMSK4HLCSxg